### PR TITLE
docs: add CLAUDE.md, PRD, DOMAIN, PARITY, ADR-002

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 All notable changes to cc-lens are documented here. This project follows [Conventional Commits](https://www.conventionalcommits.org/).
 
-## [Unreleased] — pitimon/cc-lens fork
+## [0.3.2] — 2026-04-05
+
+### Added
+
+- Cost hero subtitle showing cache read + cache write breakdown (All window only)
+- Cache Efficiency panel labeled "(all time)" to distinguish scope from hero
+- ADR-002: Dual cost sources design decision documented
+- CLAUDE.md, PRD.md, DOMAIN.md, PARITY.md project documentation
+
+### Fixed
+
+- Hero and chart now use same date filtering via `filterDailyByWindow()` (were divergent)
+- "All" window uses JSONL daily sum (was using stats-cache, causing cost jump)
+- logger.error moved from render to useEffect (was logging every 5s on SWR re-render)
+- Renamed `window` state to `costWindow` (was shadowing global)
+- Removed emoji from Pricing Reference card title
+- Restored eslint-disable for justified AnyLine type aliases (CI was failing)
+
+## [0.3.0] — 2026-04-05
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev            # Next.js dev server (port 3000)
+npm run build          # Production build
+npm run lint           # ESLint (flat config, next/core-web-vitals + TypeScript)
+npm test               # Vitest run once
+npm run test:watch     # Vitest watch mode
+npm run test:ci        # Vitest verbose (used in CI)
+npm run verify-data    # Data accuracy smoke test (requires running server on :33033)
+npx tsc --noEmit       # Type check (also runs in pre-commit hook via lint-staged)
+node bin/cli.js        # Start via CLI (syncs to ~/.cc-lens/, port 33033, opens browser)
+node scripts/e2e-test.mjs  # Playwright E2E tests (requires running server)
+```
+
+To run a single test file: `npx vitest run __tests__/pricing.test.ts`
+
+## Architecture
+
+cc-lens reads Claude Code session data from `~/.claude/` and serves a Next.js dashboard on localhost.
+
+### Data Flow
+
+```
+~/.claude/projects/<slug>/*.jsonl   (raw session JSONL — primary source)
+~/.claude/stats-cache.json          (pre-computed aggregates — secondary)
+        ↓
+lib/readers/sessions.ts             (parse JSONL → SessionMeta)
+lib/cache.ts                        (mtime-based cache in ~/.cc-lens/cache/)
+        ↓
+lib/stats-compute.ts                (aggregate: daily activity, model totals)
+lib/costs-compute.ts                (window filtering: 1d/7d/30d/90d/All)
+lib/pricing.ts                      (model-specific cost estimation)
+        ↓
+app/api/*/route.ts                  (thin HTTP handlers, force-dynamic)
+        ↓
+app/*/page.tsx + components/        (SWR fetch, Recharts visualization)
+```
+
+### Readers Barrel Pattern
+
+`lib/claude-reader.ts` is a 3-line re-export from `lib/readers/index.ts`. All imports use `@/lib/claude-reader` for backwards compatibility. The actual implementation is split across 8 modules in `lib/readers/`:
+
+- `sessions.ts` — JSONL parsing, deduplication, cache integration
+- `projects.ts` — slug listing, file discovery, path resolution
+- `content.ts` — plans, todos, history, skills, plugins, settings
+- `memory.ts` — memory files with frontmatter parsing
+- `facets.ts`, `stats.ts`, `storage.ts`, `paths.ts`
+
+See `docs/adr/001-split-claude-reader.md` for rationale.
+
+### Dual Cost Sources
+
+- **stats-cache.json** — authoritative for all-time model breakdowns (per-model table, cache efficiency panel)
+- **JSONL sessions** — used for time-windowed charts (daily/hourly costs, hero stat)
+- Both use the same pricing formula (all 4 token types: input, output, cache_write, cache_read)
+- `filterDailyByWindow()` in `lib/costs-compute.ts` is the single source of truth for date cutoffs
+
+### CLI Entry Point (`bin/cli.js`)
+
+Not a thin wrapper — handles source sync to `~/.cc-lens/`, npm install, port finding, browser open. Runs Next.js entirely within `~/.cc-lens/` (no symlinks, avoids Turbopack root issues on Windows). Version file `.cc-lens-version` controls when source re-sync happens.
+
+### Security Model
+
+Localhost-only by design. `middleware.ts` rejects non-localhost requests on `/api/*` with 403. No auth layer — physical network isolation is the security boundary. `CC_LENS_HOST` env var can override but triggers a warning.
+
+## Key Design Decisions
+
+- **mtime cache** (`lib/cache.ts`): Stores parsed SessionMeta keyed by file path + modification time. Provides 65x speedup (22s → 0.34s) on unchanged files.
+- **Model tracking**: Each session extracts `model` from JSONL assistant messages (most-used model wins). All cost calculations use the actual model, never hardcoded.
+- **Session deduplication**: Agent sessions can appear in multiple project directories. Dedup by session_id, keeping latest start_time.
+- **Cost includes cache tokens**: cache_read ($1.50/M for Opus) is a real Anthropic charge. Hero subtitle on "All" window shows cache breakdown for transparency.
+- **Computation extraction**: `stats-compute.ts` and `costs-compute.ts` are pure functions — no side effects, independently testable, decoupled from API routes.
+
+## Environment Variables
+
+| Variable                 | Default           | Purpose                             |
+| ------------------------ | ----------------- | ----------------------------------- |
+| `CC_LENS_PORT`           | `33033`           | Server port                         |
+| `CC_LENS_HOST`           | `127.0.0.1`       | Bind address                        |
+| `CC_LENS_FALLBACK_MODEL` | `claude-opus-4-6` | Pricing fallback for unknown models |
+
+## Testing
+
+- **Unit tests**: `__tests__/*.test.ts` — pricing formulas, decode utilities, JSONL parsing
+- **Fixtures**: `__tests__/fixtures/sample-session.jsonl`
+- **Data smoke test**: `scripts/verify-data.mjs` — 10 checks against raw JSONL (token counts, model tracking, deduplication, cost consistency)
+- **E2E tests**: `scripts/e2e-test.mjs` — Playwright headless, 14 checks across all pages + API endpoints
+- **Pre-commit**: Husky + lint-staged runs `tsc --noEmit` on staged `.ts/.tsx` files
+- **CI**: GitHub Actions runs lint → tsc → vitest → build on push/PR

--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -1,0 +1,86 @@
+# Domain Model — cc-lens
+
+## Core Entities
+
+### SessionMeta
+
+The primary domain object. Derived by parsing one `.jsonl` file from `~/.claude/projects/<slug>/`.
+
+| Field                         | Type       | Source                                            | Invariant                                            |
+| ----------------------------- | ---------- | ------------------------------------------------- | ---------------------------------------------------- |
+| `session_id`                  | string     | JSONL filename (without .jsonl)                   | Unique across all projects after dedup               |
+| `model`                       | string     | Most-used model from assistant messages           | Never empty — falls back to `claude-opus-4-6`        |
+| `input_tokens`                | number     | Sum of `usage.input_tokens` from assistant lines  | Does NOT include cache_read (separate field)         |
+| `output_tokens`               | number     | Sum of `usage.output_tokens` from assistant lines | —                                                    |
+| `cache_read_input_tokens`     | number     | Sum of `usage.cache_read_input_tokens`            | Tokens served from prompt cache (cheaper than input) |
+| `cache_creation_input_tokens` | number     | Sum of `usage.cache_creation_input_tokens`        | Tokens written to prompt cache                       |
+| `start_time`                  | ISO string | First `timestamp` in JSONL                        | UTC                                                  |
+| `duration_minutes`            | number     | (last_timestamp - first_timestamp) / 60000        | Can be 0 for single-message sessions                 |
+
+**Key invariant**: `input_tokens + output_tokens` = unique tokens processed. Cache tokens are separate and overlap with input context.
+
+### Cost Calculation
+
+```
+cost = input_tokens × model.input_price
+     + output_tokens × model.output_price
+     + cache_creation_input_tokens × model.cacheWrite_price
+     + cache_read_input_tokens × model.cacheRead_price
+```
+
+**Invariants**:
+
+- All 4 token types are always included (never partial)
+- Model pricing comes from `lib/pricing.ts` PRICING table
+- Unknown models fall back to opus-4-6 pricing (with console.warn)
+- `totalTokens` in hero stat = `input + output` only (cache shown separately)
+
+### DailyCost / HourlyCost
+
+Aggregated cost buckets used by the costs page chart.
+
+| Field           | Invariant                                                              |
+| --------------- | ---------------------------------------------------------------------- |
+| `date` / `hour` | UTC date string (YYYY-MM-DD) or label (MM-DD HH:00)                    |
+| `costs`         | `Record<model, cost>` — per-model breakdown within the bucket          |
+| `total`         | Sum of all model costs — must equal `Object.values(costs).reduce(sum)` |
+
+**Key invariant**: Date keys are UTC (from `ts.slice(0, 10)` on ISO timestamps). Client filtering must also use UTC cutoffs.
+
+### StatsCache
+
+Pre-computed by Claude Code, stored at `~/.claude/stats-cache.json`. Read-only for cc-lens.
+
+| Field           | Usage                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| `modelUsage`    | Authoritative all-time token totals per model — used for per-model table and cache efficiency panel |
+| `dailyActivity` | Historical daily message/session counts — merged with fresh JSONL data                              |
+
+**Key invariant**: `modelUsage` may include models/sessions no longer present as JSONL files. It is NOT the source of truth for time-windowed costs — JSONL sessions are.
+
+## Data Source Priority
+
+| Data                                | Source                                                             | When   |
+| ----------------------------------- | ------------------------------------------------------------------ | ------ |
+| Time-windowed costs (1d/7d/30d/90d) | JSONL sessions via `filterDailyByWindow()`                         | Always |
+| All-time cost hero                  | JSONL daily sum (falls back to stats-cache if daily is empty)      | Always |
+| Per-model breakdown table           | `stats-cache.json` modelUsage                                      | Always |
+| Cache efficiency panel              | `stats-cache.json` modelUsage (labeled "all time")                 | Always |
+| Daily activity chart                | Merged: stats-cache + fresh JSONL (JSONL overrides for same dates) | Always |
+
+## Deduplication Rules
+
+- Sessions deduplicated by `session_id` across all project directories
+- When duplicate found: keep the one with the latest `start_time`
+- Agent sessions (`agent-*`) commonly appear in multiple projects
+
+## Pricing Table (as of v0.3.2)
+
+| Model             | Input $/M | Output $/M | Cache Write $/M | Cache Read $/M |
+| ----------------- | --------- | ---------- | --------------- | -------------- |
+| claude-opus-4-6   | $15.00    | $75.00     | $18.75          | $1.50          |
+| claude-opus-4-5   | $15.00    | $75.00     | $18.75          | $1.50          |
+| claude-sonnet-4-6 | $3.00     | $15.00     | $3.75           | $0.30          |
+| claude-haiku-4-5  | $0.80     | $4.00      | $1.00           | $0.08          |
+
+Fuzzy matching: model strings with date suffixes (e.g., `claude-haiku-4-5-20251001`) match their prefix.

--- a/PARITY.md
+++ b/PARITY.md
@@ -1,0 +1,79 @@
+# Fork Parity — pitimon/cc-lens vs Arindam200/cc-lens
+
+Forked from [Arindam200/cc-lens](https://github.com/Arindam200/cc-lens) at v0.2.7 (commit `862e842`).
+
+## What We Changed
+
+### Performance
+
+| Metric              | Upstream                          | Fork                                       |
+| ------------------- | --------------------------------- | ------------------------------------------ |
+| /api/stats response | 22s                               | 0.34s (65x)                                |
+| Mechanism           | Full JSONL re-parse every request | mtime-based session cache (`lib/cache.ts`) |
+| Default port        | 3000                              | 33033                                      |
+
+### Data Accuracy (M0 milestone — 6 issues)
+
+- **Model tracking**: Extract actual model from JSONL assistant messages → `SessionMeta.model`. Upstream hardcoded `claude-opus-4-6` pricing for all sessions (18x overestimate for Haiku).
+- **Token counting**: Hero stat shows `input + output` only. Upstream included cache tokens in total (16.9B → 26.1M after fix).
+- **Cost formula unified**: All endpoints (daily, hourly, project, session) use same 4-token-type formula with actual model pricing. Upstream had inconsistent formulas.
+- **Session deduplication**: 625 duplicate JSONL files across projects no longer double-counted.
+- **Cost window filtering**: `lib/costs-compute.ts` — single source of truth. Upstream hero used date cutoff but chart used `slice(-N)`.
+
+### Security (M2 milestone — 5 issues)
+
+- **Localhost-only**: Binds `127.0.0.1` by default (upstream bound `0.0.0.0`)
+- **CORS middleware**: Rejects non-localhost requests on `/api/*`
+- **Memory PATCH**: Added `path.resolve()` + `..` check for defense-in-depth
+- **Error responses**: Sanitized — no file paths or stack traces leaked
+- **Theme XSS**: Validates localStorage theme against `['light','dark']` allowlist
+- **Export disclaimer**: Warning about prompt text in exports
+
+### Code Quality (M3 milestone — 7 issues)
+
+- **claude-reader.ts**: 804-line monolith → 8 modules under `lib/readers/` with barrel re-export
+- **Computation extraction**: `lib/stats-compute.ts` + `lib/costs-compute.ts` — pure functions, testable
+- **Error boundaries**: `app/error.tsx` with retry button
+- **Health endpoint**: `GET /api/health` → `{ status, version, claudeDir }`
+- **Silent catch blocks**: Categorized with comments (ENOENT → silent, parse error → warn)
+
+### Testing & CI (M1 milestone — 6 issues)
+
+- **Vitest**: 50 unit tests (pricing, decode, claude-reader)
+- **Data smoke test**: `scripts/verify-data.mjs` — 10 accuracy checks vs raw JSONL
+- **E2E tests**: `scripts/e2e-test.mjs` — 14 Playwright checks across all pages
+- **GitHub Actions CI**: lint → tsc → vitest → build on push/PR
+- **Pre-commit hooks**: Husky + lint-staged (tsc on staged .ts/.tsx)
+
+### Documentation (M4 milestone — 5 issues)
+
+- CLAUDE.md, CONTRIBUTING.md, CHANGELOG.md, docs/api.md (16 endpoints), docs/adr/001
+- JSDoc on public pricing functions
+- getPricing warns on unknown model fallback
+
+### UI
+
+- Collapsible sidebar with Lucide icons and localStorage persistence
+- 1d/7d/30d/90d/All time window selector on cost charts
+- Hourly cost chart for 1d view
+- Daily cost gap-fill from JSONL after stats-cache cutoff
+- Cost hero subtitle: cache read + cache write breakdown (All window)
+- Cache Efficiency panel labeled "(all time)"
+- Rebranded: GitHub link, CLI banner, package.json → pitimon
+
+### Removed from Upstream
+
+- Auth layer (token login) — unnecessary for localhost-only tool
+- `proxy.ts` middleware (replaced with simpler `middleware.ts`)
+
+## What We Kept
+
+- All original dashboard pages (overview, projects, sessions, costs, tools, activity, history, memory, todos, plans, settings, export)
+- Session replay with per-turn token display
+- CLI distribution model (`bin/cli.js` → `~/.cc-lens/`)
+- SWR polling (5s refresh)
+- Tailwind + Radix UI + Recharts component stack
+
+## Upstream Sync Status
+
+**Not tracking upstream changes.** This fork diverged significantly in architecture (readers split, computation extraction, cache layer, middleware). Manual cherry-pick of upstream features is possible but requires integration work.

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,54 @@
+# Product Requirements Document — cc-lens
+
+## What
+
+Local-first analytics dashboard for Claude Code. Visualizes token usage, costs, sessions, and project activity from `~/.claude/` data.
+
+## Why
+
+Claude Code generates rich session telemetry but provides no built-in way to review spending, usage patterns, or session history. cc-lens fills this gap without sending data to any cloud service.
+
+## Who
+
+Individual Claude Code users who want to:
+
+- Track API spend across models and time windows
+- Understand which projects and sessions consume the most tokens
+- Review session replays with per-turn cost visibility
+- Monitor cache efficiency and savings
+- Browse plans, todos, memory, and settings in one place
+
+## Scope
+
+### In Scope
+
+- Read-only dashboard for `~/.claude/` data (JSONL sessions, stats-cache, plans, todos, memory, settings)
+- Cost estimation using hardcoded Anthropic pricing (all 4 token types)
+- Time-windowed views: 1d (hourly), 7d, 30d, 90d, All
+- Session replay with tool calls, thinking blocks, token timeline
+- Export/import of dashboard data as `.ccboard.json`
+- Memory file editing (PATCH endpoint with path traversal protection)
+- CLI distribution via `npx` or local `node bin/cli.js`
+
+### Out of Scope
+
+- Real-time Anthropic API integration (no API key required)
+- Multi-user / team dashboards
+- Cloud deployment or hosted version
+- Billing alerts or budget enforcement
+- Modification of Claude Code session data (read-only except memory)
+- Support for non-Claude AI tools
+
+## Success Criteria
+
+- Page load < 1s on warm cache (achieved: 0.34s)
+- Cost accuracy: dashboard values match manual JSONL calculation (verified by `npm run verify-data`)
+- Zero telemetry: no outbound network requests
+- Works on macOS, Linux, Windows with Node.js 18+
+
+## Non-Functional Requirements
+
+- Localhost-only by default (middleware enforced)
+- No authentication — security via network isolation
+- SWR polling every 5s for live updates while dashboard is open
+- Session deduplication across project directories

--- a/docs/adr/002-dual-cost-sources.md
+++ b/docs/adr/002-dual-cost-sources.md
@@ -1,0 +1,61 @@
+# ADR-002: Dual Cost Sources — stats-cache vs JSONL sessions
+
+## Status
+
+Accepted
+
+## Context
+
+cc-lens has two independent sources of cost data:
+
+1. **stats-cache.json** (`~/.claude/stats-cache.json`) — pre-computed by Claude Code, updated periodically. Contains `modelUsage` with all-time token aggregates per model.
+2. **JSONL sessions** (`~/.claude/projects/<slug>/*.jsonl`) — raw session files, always fresh but require parsing.
+
+The costs page needs to show costs across time windows (1d/7d/30d/90d/All). A single source cannot serve all needs:
+
+- stats-cache has no per-day granularity (can't filter by window)
+- JSONL sessions may not cover the full history (old files get deleted)
+
+## Decision
+
+Use **JSONL sessions as the primary source** for time-windowed cost views, with **stats-cache as authoritative fallback** for all-time model breakdowns.
+
+### Data Source Assignment
+
+| Display                   | Source                                            | Rationale                                                   |
+| ------------------------- | ------------------------------------------------- | ----------------------------------------------------------- |
+| Hero cost (1d/7d/30d/90d) | JSONL daily/hourly sums                           | Window filtering requires per-session timestamps            |
+| Hero cost (All)           | JSONL daily sum, fallback to stats-cache if empty | Consistency with other windows; fallback for fresh installs |
+| Cost Over Time chart      | JSONL daily/hourly                                | Must align with hero number                                 |
+| Per-Model Token Table     | stats-cache modelUsage                            | Authoritative all-time aggregates                           |
+| Cache Efficiency Panel    | stats-cache modelUsage                            | Needs all-time totals for meaningful hit rate               |
+| Cost by Project           | JSONL sessions                                    | Per-project granularity not available in stats-cache        |
+
+### Window Filtering
+
+Single utility `filterDailyByWindow()` in `lib/costs-compute.ts` used by both hero and chart. Uses UTC date cutoff (`toISOString().slice(0, 10)`) matching the API route's date key format.
+
+## Consequences
+
+### Positive
+
+- Time-windowed costs are always fresh (no waiting for stats-cache refresh)
+- Hero and chart values always match (shared filtering utility)
+- Per-model table shows complete history including deleted sessions
+
+### Negative
+
+- **"All" hero may differ from per-model table total** — JSONL sum covers only existing files, stats-cache covers full history. Gap is visible when old JSONL files are deleted.
+- **Cache cost breakdown is all-time only** — subtitle "incl. $X cache read + $Y cache write" shown only on All window because per-window cache breakdown requires additional API fields.
+
+### Mitigations
+
+- Cache Efficiency panel labeled "(all time)" to distinguish scope from hero
+- Hero subtitle only shown on All window to avoid scope mismatch
+- `verify-data.mjs` smoke test checks daily sum > 0 and model tracking
+
+## Related
+
+- ADR-001: Split claude-reader.ts into focused modules
+- `lib/costs-compute.ts`: filterDailyByWindow, sumDailyCost, sumHourlyCost
+- `lib/stats-compute.ts`: computeModelTotals (stats-cache path)


### PR DESCRIPTION
## Summary
- **CLAUDE.md** — commands, architecture, data flow for Claude Code agents
- **PRD.md** — product scope, success criteria, what's in/out of scope
- **DOMAIN.md** — entity invariants (SessionMeta, cost formula, dedup rules, pricing table)
- **PARITY.md** — fork vs upstream diff with before/after metrics
- **ADR-002** — dual cost sources design decision (stats-cache vs JSONL)
- **CHANGELOG.md** — v0.3.2 release notes added

## Test plan
- [ ] No code changes — documentation only
- [ ] CI should pass (no .ts/.tsx files modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)