### PR TITLE
feat: per-window cache breakdown and savings

### DIFF
--- a/app/api/costs/route.ts
+++ b/app/api/costs/route.ts
@@ -53,22 +53,20 @@ export async function GET() {
 
   // ── Daily + Hourly cost — ALL from JSONL sessions (single source of truth) ─
   // This ensures 1d/7d/30d/90d/All use the same calculation method
-  const dailyMap = new Map<
-    string,
-    { costs: Record<string, number>; total: number }
-  >();
+  type CostBucket = {
+    costs: Record<string, number>;
+    total: number;
+    cache_read_cost: number;
+    cache_write_cost: number;
+    cache_savings: number;
+  };
+  const dailyMap = new Map<string, CostBucket>();
   const now = new Date();
   const cutoff24h = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-  const hourlyMap = new Map<
-    string,
-    { costs: Record<string, number>; total: number }
-  >();
+  const hourlyMap = new Map<string, CostBucket>();
 
-  // Track cache cost breakdown for hero subtitle (shown on "All" window only).
-  // Headline cost includes all 4 token types by design — cache_read IS a real
-  // Anthropic charge, just 10x cheaper than regular input.
-  // NOTE: These are summed from JSONL sessions, not the stats-cache.
-  // They may differ slightly from total_cost when the stats cache is stale.
+  // Track all-time cache cost totals.
+  // NOTE: Summed from JSONL sessions, not stats-cache — may differ when stale.
   let totalCacheReadCost = 0;
   let totalCacheWriteCost = 0;
 
@@ -87,12 +85,24 @@ export async function GET() {
       (s.output_tokens ?? 0) * p.output +
       cacheWriteCost +
       cacheReadCost;
+    const cacheSavings =
+      (s.cache_read_input_tokens ?? 0) * (p.input - p.cacheRead);
     totalCacheReadCost += cacheReadCost;
     totalCacheWriteCost += cacheWriteCost;
 
     // Daily aggregation
-    const dayEntry = dailyMap.get(date) ?? { costs: {}, total: 0 };
+    const emptyBucket = (): CostBucket => ({
+      costs: {},
+      total: 0,
+      cache_read_cost: 0,
+      cache_write_cost: 0,
+      cache_savings: 0,
+    });
+    const dayEntry = dailyMap.get(date) ?? emptyBucket();
     dayEntry.total += cost;
+    dayEntry.cache_read_cost += cacheReadCost;
+    dayEntry.cache_write_cost += cacheWriteCost;
+    dayEntry.cache_savings += cacheSavings;
     dayEntry.costs[sessionModel] = (dayEntry.costs[sessionModel] ?? 0) + cost;
     dailyMap.set(date, dayEntry);
 
@@ -103,8 +113,11 @@ export async function GET() {
       const dd = String(sessionTime.getDate()).padStart(2, "0");
       const hh = String(sessionTime.getHours()).padStart(2, "0");
       const hourLabel = `${mm}-${dd} ${hh}:00`;
-      const hourEntry = hourlyMap.get(hourLabel) ?? { costs: {}, total: 0 };
+      const hourEntry = hourlyMap.get(hourLabel) ?? emptyBucket();
       hourEntry.total += cost;
+      hourEntry.cache_read_cost += cacheReadCost;
+      hourEntry.cache_write_cost += cacheWriteCost;
+      hourEntry.cache_savings += cacheSavings;
       hourEntry.costs[sessionModel] =
         (hourEntry.costs[sessionModel] ?? 0) + cost;
       hourlyMap.set(hourLabel, hourEntry);
@@ -112,11 +125,25 @@ export async function GET() {
   }
 
   const daily: DailyCost[] = [...dailyMap.entries()]
-    .map(([date, { costs, total }]) => ({ date, costs, total }))
+    .map(([date, b]) => ({
+      date,
+      costs: b.costs,
+      total: b.total,
+      cache_read_cost: b.cache_read_cost,
+      cache_write_cost: b.cache_write_cost,
+      cache_savings: b.cache_savings,
+    }))
     .sort((a, b) => a.date.localeCompare(b.date));
 
   const hourly: HourlyCost[] = [...hourlyMap.entries()]
-    .map(([hour, { costs, total }]) => ({ hour, costs, total }))
+    .map(([hour, b]) => ({
+      hour,
+      costs: b.costs,
+      total: b.total,
+      cache_read_cost: b.cache_read_cost,
+      cache_write_cost: b.cache_write_cost,
+      cache_savings: b.cache_savings,
+    }))
     .sort((a, b) => a.hour.localeCompare(b.hour));
 
   // ── Cost by project ────────────────────────────────────────────────────────

--- a/app/costs/page.tsx
+++ b/app/costs/page.tsx
@@ -17,6 +17,7 @@ import {
   filterDailyByWindow,
   sumDailyCost,
   sumHourlyCost,
+  sumCacheBreakdown,
 } from "@/lib/costs-compute";
 import type { CostAnalytics } from "@/types/claude";
 
@@ -65,16 +66,27 @@ export default function CostsPage() {
 
     // 1d: sum hourly data (last 24h)
     if (costWindow === 1) {
-      return { cost: sumHourlyCost(data.hourly ?? []), savings: 0 };
+      const hrs = data.hourly ?? [];
+      const cache = sumCacheBreakdown(hrs);
+      return {
+        cost: sumHourlyCost(hrs),
+        cacheReadCost: cache.cacheReadCost,
+        cacheWriteCost: cache.cacheWriteCost,
+        savings: cache.cacheSavings,
+      };
     }
 
     // 7d/30d/90d/All: use shared filtering utility (single source of truth)
     const days = filterDailyByWindow(data.daily, costWindow);
     const cost = sumDailyCost(days);
-    // For "All": fall back to stats-cache if JSONL daily is empty
+    const cache = sumCacheBreakdown(days);
     const finalCost = costWindow === 365 && cost === 0 ? data.total_cost : cost;
-    const savings = costWindow === 365 ? data.total_savings : 0;
-    return { cost: finalCost, savings };
+    return {
+      cost: finalCost,
+      cacheReadCost: cache.cacheReadCost,
+      cacheWriteCost: cache.cacheWriteCost,
+      savings: cache.cacheSavings,
+    };
   }, [data, costWindow]);
 
   return (
@@ -110,13 +122,12 @@ export default function CostsPage() {
                 <p className="text-2xl font-bold text-[#d97706]">
                   {formatCost(filtered.cost)}
                 </p>
-                {costWindow === 365 &&
-                  data.cache_read_cost + data.cache_write_cost > 0 && (
-                    <p className="text-[11px] text-muted-foreground/60 font-mono mt-0.5">
-                      incl. {formatCost(data.cache_read_cost)} cache read +{" "}
-                      {formatCost(data.cache_write_cost)} cache write
-                    </p>
-                  )}
+                {filtered.cacheReadCost + filtered.cacheWriteCost > 0 && (
+                  <p className="text-[11px] text-muted-foreground/60 font-mono mt-0.5">
+                    incl. {formatCost(filtered.cacheReadCost)} cache read +{" "}
+                    {formatCost(filtered.cacheWriteCost)} cache write
+                  </p>
+                )}
               </div>
               {filtered.savings > 0 && (
                 <>

--- a/lib/costs-compute.ts
+++ b/lib/costs-compute.ts
@@ -24,3 +24,22 @@ export function sumDailyCost(days: DailyCost[]): number {
 export function sumHourlyCost(hours: HourlyCost[]): number {
   return hours.reduce((sum, h) => sum + h.total, 0);
 }
+
+/** Aggregate cache cost breakdown and savings from daily or hourly entries */
+export function sumCacheBreakdown(
+  entries: Array<{
+    cache_read_cost: number;
+    cache_write_cost: number;
+    cache_savings: number;
+  }>,
+): { cacheReadCost: number; cacheWriteCost: number; cacheSavings: number } {
+  let cacheReadCost = 0;
+  let cacheWriteCost = 0;
+  let cacheSavings = 0;
+  for (const e of entries) {
+    cacheReadCost += e.cache_read_cost;
+    cacheWriteCost += e.cache_write_cost;
+    cacheSavings += e.cache_savings;
+  }
+  return { cacheReadCost, cacheWriteCost, cacheSavings };
+}

--- a/types/claude.ts
+++ b/types/claude.ts
@@ -253,6 +253,9 @@ export interface DailyCost {
   date: string;
   costs: Record<string, number>;
   total: number;
+  cache_read_cost: number;
+  cache_write_cost: number;
+  cache_savings: number;
 }
 
 export interface ProjectCost {
@@ -267,6 +270,9 @@ export interface HourlyCost {
   hour: string; // "HH:00"
   costs: Record<string, number>;
   total: number;
+  cache_read_cost: number;
+  cache_write_cost: number;
+  cache_savings: number;
 }
 
 export interface CostAnalytics {


### PR DESCRIPTION
## Summary
Cache savings and cost breakdown now shown for **all time windows** (1d/7d/30d/90d/All), not just All.

## Before
- 1d/7d/30d/90d: only hero cost, no cache breakdown, no savings
- All: hero + subtitle + savings + without cache

## After
Every window shows:
- Hero cost with subtitle: `incl. $X cache read + $Y cache write`
- Cache Savings: `$Z` (tokens saved by cache × price delta)
- Without Cache: `$W` (cost + savings)

## Changes
- `types/claude.ts`: DailyCost/HourlyCost gain `cache_read_cost`, `cache_write_cost`, `cache_savings`
- `app/api/costs/route.ts`: compute per-bucket cache costs and savings
- `lib/costs-compute.ts`: `sumCacheBreakdown()` aggregates cache fields
- `app/costs/page.tsx`: `filtered` memo returns per-window breakdown

## Verification
```
  1d: cost=$1,321  savings=$8,113
  7d: cost=$1,657  savings=$9,578
 30d: cost=$21,928 savings=$141,059
 90d: cost=$22,145 savings=$142,292
```

## Test plan
- [ ] `npx tsc --noEmit` clean
- [ ] `npm test` passes (50 tests)
- [ ] Each window shows cache breakdown subtitle
- [ ] Cache Savings + Without Cache visible on all windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)