### PR TITLE
fix: CLI ETARGET on fresh install — copy package-lock.json

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -104,6 +104,10 @@ function syncSource(pkg) {
       2,
     ),
   );
+  const lockSrc = path.join(PKG_DIR, "package-lock.json");
+  if (fs.existsSync(lockSrc)) {
+    fs.copyFileSync(lockSrc, path.join(CACHE_DIR, "package-lock.json"));
+  }
 }
 
 async function main() {
@@ -140,15 +144,11 @@ async function main() {
     if (needsInstall) {
       console.log(`  ${DIM}Setting up (first run, may take a minute)…${R}\n`);
       await new Promise((resolve, reject) => {
-        const install = spawn(
-          "npm",
-          ["install", "--prefer-offline", "--no-package-lock"],
-          {
-            cwd: CACHE_DIR,
-            stdio: "inherit",
-            shell: true,
-          },
-        );
+        const install = spawn("npm", ["install", "--prefer-offline"], {
+          cwd: CACHE_DIR,
+          stdio: "inherit",
+          shell: true,
+        });
         install.on("exit", (code) =>
           code === 0
             ? resolve()


### PR DESCRIPTION
## Summary
- Copy `package-lock.json` into `~/.cc-lens/` during `syncSource()` so npm uses pre-resolved dependency versions
- Remove `--no-package-lock` flag from `npm install` command
- Fixes fresh install failure: `npm error code ETARGET` on `@next/env@16.2.2`

Closes #40

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 50/50 pass
- [x] `rm -rf ~/.cc-lens/ && node bin/cli.js` — npm install succeeds, server starts
- [x] `~/.cc-lens/package-lock.json` exists after install
- [ ] Second run skips install (no re-sync)