### PR TITLE
fix: 8-Habit QA findings — 4 items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Test
         run: npm run test:ci
 
+      - name: Coverage
+        run: npx vitest run --coverage
+
       - name: Build
         run: npm run build

--- a/__tests__/costs-compute.test.ts
+++ b/__tests__/costs-compute.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterDailyByWindow,
+  sumDailyCost,
+  sumHourlyCost,
+  sumCacheBreakdown,
+} from "@/lib/costs-compute";
+import type { DailyCost, HourlyCost } from "@/types/claude";
+
+function dailyCost(overrides: Partial<DailyCost> = {}): DailyCost {
+  return {
+    date: "2026-04-01",
+    costs: {},
+    total: 0,
+    cache_read_cost: 0,
+    cache_write_cost: 0,
+    cache_savings: 0,
+    ...overrides,
+  };
+}
+
+function hourlyCost(overrides: Partial<HourlyCost> = {}): HourlyCost {
+  return {
+    hour: "14:00",
+    costs: {},
+    total: 0,
+    cache_read_cost: 0,
+    cache_write_cost: 0,
+    cache_savings: 0,
+    ...overrides,
+  };
+}
+
+describe("filterDailyByWindow", () => {
+  const today = new Date().toISOString().slice(0, 10);
+  const daysAgo = (n: number) => {
+    const d = new Date();
+    d.setDate(d.getDate() - n);
+    return d.toISOString().slice(0, 10);
+  };
+
+  const daily: DailyCost[] = [
+    dailyCost({ date: daysAgo(100), total: 1 }),
+    dailyCost({ date: daysAgo(50), total: 2 }),
+    dailyCost({ date: daysAgo(10), total: 3 }),
+    dailyCost({ date: daysAgo(3), total: 4 }),
+    dailyCost({ date: today, total: 5 }),
+  ];
+
+  it("returns all entries for 365 (All) window", () => {
+    expect(filterDailyByWindow(daily, 365)).toHaveLength(5);
+  });
+
+  it("filters to last 90 days", () => {
+    const result = filterDailyByWindow(daily, 90);
+    expect(result).toHaveLength(4);
+    expect(result.every((d) => d.date >= daysAgo(90))).toBe(true);
+  });
+
+  it("filters to last 30 days", () => {
+    const result = filterDailyByWindow(daily, 30);
+    expect(result).toHaveLength(3);
+  });
+
+  it("filters to last 7 days", () => {
+    const result = filterDailyByWindow(daily, 7);
+    expect(result).toHaveLength(2);
+  });
+
+  it("filters to last 1 day", () => {
+    const result = filterDailyByWindow(daily, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toBe(today);
+  });
+
+  it("returns empty array when no entries match", () => {
+    const old = [dailyCost({ date: "2020-01-01", total: 1 })];
+    expect(filterDailyByWindow(old, 1)).toHaveLength(0);
+  });
+
+  it("handles empty input", () => {
+    expect(filterDailyByWindow([], 30)).toEqual([]);
+  });
+});
+
+describe("sumDailyCost", () => {
+  it("sums totals across entries", () => {
+    const days = [
+      dailyCost({ total: 1.5 }),
+      dailyCost({ total: 2.5 }),
+      dailyCost({ total: 3.0 }),
+    ];
+    expect(sumDailyCost(days)).toBeCloseTo(7.0);
+  });
+
+  it("returns 0 for empty array", () => {
+    expect(sumDailyCost([])).toBe(0);
+  });
+});
+
+describe("sumHourlyCost", () => {
+  it("sums totals across entries", () => {
+    const hours = [hourlyCost({ total: 0.5 }), hourlyCost({ total: 1.5 })];
+    expect(sumHourlyCost(hours)).toBeCloseTo(2.0);
+  });
+
+  it("returns 0 for empty array", () => {
+    expect(sumHourlyCost([])).toBe(0);
+  });
+});
+
+describe("sumCacheBreakdown", () => {
+  it("aggregates cache costs and savings", () => {
+    const entries = [
+      { cache_read_cost: 1, cache_write_cost: 2, cache_savings: 10 },
+      { cache_read_cost: 3, cache_write_cost: 4, cache_savings: 20 },
+    ];
+    expect(sumCacheBreakdown(entries)).toEqual({
+      cacheReadCost: 4,
+      cacheWriteCost: 6,
+      cacheSavings: 30,
+    });
+  });
+
+  it("returns zeros for empty array", () => {
+    expect(sumCacheBreakdown([])).toEqual({
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      cacheSavings: 0,
+    });
+  });
+});

--- a/__tests__/stats-compute.test.ts
+++ b/__tests__/stats-compute.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeDailyActivityFromSessions,
+  mergeDailyActivity,
+  computeModelTotals,
+  computeTotalToolCalls,
+  computeSessionPeriods,
+} from "@/lib/stats-compute";
+import type { DailyActivity, ModelUsage, SessionMeta } from "@/types/claude";
+
+function sessionMeta(overrides: Partial<SessionMeta> = {}): SessionMeta {
+  return {
+    session_id: "test-session",
+    project_path: "/test",
+    start_time: "2026-04-01T10:00:00Z",
+    duration_minutes: 30,
+    model: "claude-sonnet-4-6",
+    user_message_count: 5,
+    assistant_message_count: 5,
+    tool_counts: {},
+    languages: {},
+    git_commits: 0,
+    git_pushes: 0,
+    input_tokens: 1000,
+    output_tokens: 500,
+    first_prompt: "test",
+    user_interruptions: 0,
+    user_response_times: [],
+    tool_errors: 0,
+    tool_error_categories: {},
+    uses_task_agent: false,
+    uses_mcp: false,
+    uses_web_search: false,
+    uses_web_fetch: false,
+    lines_added: 0,
+    lines_removed: 0,
+    files_modified: 0,
+    message_hours: [],
+    user_message_timestamps: [],
+    ...overrides,
+  };
+}
+
+describe("computeDailyActivityFromSessions", () => {
+  it("aggregates sessions by date", () => {
+    const sessions = [
+      sessionMeta({
+        session_id: "s1",
+        start_time: "2026-04-01T10:00:00Z",
+        user_message_count: 3,
+        assistant_message_count: 2,
+        tool_counts: { Read: 5, Write: 3 },
+      }),
+      sessionMeta({
+        session_id: "s2",
+        start_time: "2026-04-01T14:00:00Z",
+        user_message_count: 1,
+        assistant_message_count: 1,
+        tool_counts: { Bash: 2 },
+      }),
+    ];
+    const result = computeDailyActivityFromSessions(sessions);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      date: "2026-04-01",
+      messageCount: 7, // 3+2+1+1
+      sessionCount: 2,
+      toolCallCount: 10, // 5+3+2
+    });
+  });
+
+  it("sorts by date ascending", () => {
+    const sessions = [
+      sessionMeta({ session_id: "s1", start_time: "2026-04-03T10:00:00Z" }),
+      sessionMeta({ session_id: "s2", start_time: "2026-04-01T10:00:00Z" }),
+    ];
+    const result = computeDailyActivityFromSessions(sessions);
+    expect(result[0].date).toBe("2026-04-01");
+    expect(result[1].date).toBe("2026-04-03");
+  });
+
+  it("skips sessions with invalid date format", () => {
+    const sessions = [sessionMeta({ session_id: "s1", start_time: "invalid" })];
+    expect(computeDailyActivityFromSessions(sessions)).toHaveLength(0);
+  });
+
+  it("returns empty array for no sessions", () => {
+    expect(computeDailyActivityFromSessions([])).toEqual([]);
+  });
+});
+
+describe("mergeDailyActivity", () => {
+  it("session data overrides stats for same date", () => {
+    const fromStats: DailyActivity[] = [
+      {
+        date: "2026-04-01",
+        messageCount: 10,
+        sessionCount: 2,
+        toolCallCount: 5,
+      },
+    ];
+    const fromSessions: DailyActivity[] = [
+      {
+        date: "2026-04-01",
+        messageCount: 15,
+        sessionCount: 3,
+        toolCallCount: 8,
+      },
+    ];
+    const result = mergeDailyActivity(fromStats, fromSessions);
+    expect(result).toHaveLength(1);
+    expect(result[0].messageCount).toBe(15);
+  });
+
+  it("merges entries from different dates", () => {
+    const fromStats: DailyActivity[] = [
+      {
+        date: "2026-04-01",
+        messageCount: 10,
+        sessionCount: 2,
+        toolCallCount: 5,
+      },
+    ];
+    const fromSessions: DailyActivity[] = [
+      {
+        date: "2026-04-02",
+        messageCount: 5,
+        sessionCount: 1,
+        toolCallCount: 3,
+      },
+    ];
+    const result = mergeDailyActivity(fromStats, fromSessions);
+    expect(result).toHaveLength(2);
+    expect(result[0].date).toBe("2026-04-01");
+    expect(result[1].date).toBe("2026-04-02");
+  });
+
+  it("handles both empty arrays", () => {
+    expect(mergeDailyActivity([], [])).toEqual([]);
+  });
+});
+
+describe("computeModelTotals", () => {
+  it("computes cost and token totals across models", () => {
+    const usage: Record<string, ModelUsage> = {
+      "claude-sonnet-4-6": {
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        costUSD: 0,
+        webSearchRequests: 0,
+      },
+    };
+    const result = computeModelTotals(usage);
+    expect(result.totalInputTokens).toBe(1000);
+    expect(result.totalOutputTokens).toBe(500);
+    expect(result.totalCacheReadTokens).toBe(200);
+    expect(result.totalCacheWriteTokens).toBe(100);
+    expect(result.totalTokens).toBe(1500);
+    expect(result.totalCost).toBeGreaterThan(0);
+    expect(result.totalCacheSavings).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns zeros for empty usage", () => {
+    const result = computeModelTotals({});
+    expect(result.totalCost).toBe(0);
+    expect(result.totalTokens).toBe(0);
+  });
+});
+
+describe("computeTotalToolCalls", () => {
+  it("sums tool calls across sessions", () => {
+    const sessions = [
+      sessionMeta({ tool_counts: { Read: 5, Write: 3 } }),
+      sessionMeta({ tool_counts: { Bash: 10 } }),
+    ];
+    expect(computeTotalToolCalls(sessions)).toBe(18);
+  });
+
+  it("returns 0 for no sessions", () => {
+    expect(computeTotalToolCalls([])).toBe(0);
+  });
+
+  it("handles sessions with empty tool_counts", () => {
+    const sessions = [sessionMeta({ tool_counts: {} })];
+    expect(computeTotalToolCalls(sessions)).toBe(0);
+  });
+});
+
+describe("computeSessionPeriods", () => {
+  it("counts sessions this month and this week", () => {
+    const now = new Date();
+    const today = now.toISOString();
+    const sessions = [
+      sessionMeta({ start_time: today }),
+      sessionMeta({ start_time: "2020-01-01T00:00:00Z" }),
+    ];
+    const result = computeSessionPeriods(sessions);
+    expect(result.sessionsThisMonth).toBe(1);
+    expect(result.sessionsThisWeek).toBe(1);
+  });
+
+  it("returns zeros for no sessions", () => {
+    const result = computeSessionPeriods([]);
+    expect(result.sessionsThisMonth).toBe(0);
+    expect(result.sessionsThisWeek).toBe(0);
+  });
+});

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from "next/server";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
+import pkg from "../../../package.json";
 
 export const dynamic = "force-dynamic";
 
 const CLAUDE_DIR = path.join(os.homedir(), ".claude");
-const VERSION = "0.4.0";
 
 export async function GET() {
   let claudeDir = false;
@@ -19,7 +19,7 @@ export async function GET() {
 
   return NextResponse.json({
     status: claudeDir ? "ok" : "degraded",
-    version: VERSION,
+    version: pkg.version,
     claudeDir,
   });
 }

--- a/app/costs/page.tsx
+++ b/app/costs/page.tsx
@@ -3,10 +3,8 @@
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { TopBar } from "@/components/layout/top-bar";
-import {
-  CostOverTimeChart,
-  type CostWindow,
-} from "@/components/costs/cost-over-time-chart";
+import { CostOverTimeChart } from "@/components/costs/cost-over-time-chart";
+import type { CostWindow } from "@/lib/costs-compute";
 import { CostByProjectChart } from "@/components/costs/cost-by-project-chart";
 import { ModelTokenTable } from "@/components/costs/model-token-table";
 import { CacheEfficiencyPanel } from "@/components/costs/cache-efficiency-panel";

--- a/components/costs/cost-over-time-chart.tsx
+++ b/components/costs/cost-over-time-chart.tsx
@@ -36,7 +36,7 @@ function shortModel(m: string): string {
   return m;
 }
 
-export type CostWindow = 1 | 7 | 30 | 90 | 365;
+import type { CostWindow } from "@/lib/costs-compute";
 
 interface Props {
   daily: DailyCost[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-lens",
-  "version": "0.2.7",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-lens",
-      "version": "0.2.7",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4",
@@ -35,6 +35,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@vitest/coverage-v8": "^4.1.2",
         "eslint": "9.39.3",
         "eslint-config-next": "16.2.2",
         "husky": "^9.1.7",
@@ -591,6 +592,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -5235,6 +5246,37 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -5725,6 +5767,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8484,6 +8545,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -9283,6 +9351,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -10099,6 +10206,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@vitest/coverage-v8": "^4.1.2",
     "eslint": "9.39.3",
     "eslint-config-next": "16.2.2",
     "husky": "^9.1.7",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,21 @@ export default defineConfig({
     environment: "jsdom",
     include: ["__tests__/**/*.test.ts", "__tests__/**/*.test.tsx"],
     globals: true,
+    coverage: {
+      provider: "v8",
+      include: [
+        "lib/costs-compute.ts",
+        "lib/stats-compute.ts",
+        "lib/pricing.ts",
+        "lib/decode.ts",
+      ],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 60,
+        statements: 80,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Remove `CostWindow` type duplication — import from canonical `lib/costs-compute.ts`
- Health endpoint reads version from `package.json` (was hardcoded `"0.4.0"`)
- Add 27 unit tests for `stats-compute.ts` and `costs-compute.ts` (pure compute layer)
- Add `@vitest/coverage-v8` with 80% threshold on core modules + CI coverage step

Closes #41

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 77/77 pass (was 50)
- [x] `npx vitest run --coverage` — thresholds met (81.8% stmts, 84.2% funcs)
- [x] Pre-commit hook passes
- [ ] CI pipeline passes (lint → tsc → test → coverage → build)