### PR TITLE
fix: session oscillation + security residuals (6 items)

### DIFF
--- a/__tests__/security-paths.test.ts
+++ b/__tests__/security-paths.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { isValidSlug } from "@/lib/readers/projects";
 
 describe("API input validation", () => {
   describe("history route — parseInt NaN guard", () => {
@@ -51,30 +52,21 @@ describe("API input validation", () => {
       expect(file.endsWith(".md")).toBe(false);
     });
 
-    it("rejects path traversal in slug", () => {
-      const slug = "../../../etc";
-      expect(/[/\\]/.test(slug) || /\.\./.test(slug)).toBe(true);
+    it("rejects path traversal in slug via isValidSlug", () => {
+      expect(isValidSlug("../../../etc")).toBe(false);
+      expect(isValidSlug("foo/bar")).toBe(false);
+      expect(isValidSlug("foo\\bar")).toBe(false);
+      expect(isValidSlug("..")).toBe(false);
+    });
+
+    it("accepts valid slug via isValidSlug", () => {
+      expect(isValidSlug("-Users-itarun-cc-lens")).toBe(true);
+      expect(isValidSlug("my-project")).toBe(true);
     });
 
     it("rejects path traversal in file", () => {
       const file = "../../passwd";
       expect(/[/\\]/.test(file) || /\.\./.test(file)).toBe(true);
-    });
-
-    it("accepts valid input", () => {
-      const slug = "-Users-itarun-cc-lens";
-      const file = "feedback_review.md";
-      const content = "some content";
-      const valid =
-        !!slug &&
-        !!file &&
-        typeof content === "string" &&
-        file.endsWith(".md") &&
-        !/[/\\]/.test(slug) &&
-        !/\.\./.test(slug) &&
-        !/[/\\]/.test(file) &&
-        !/\.\./.test(file);
-      expect(valid).toBe(true);
     });
   });
 });

--- a/app/api/sessions/[id]/replay/route.ts
+++ b/app/api/sessions/[id]/replay/route.ts
@@ -1,20 +1,26 @@
-import { NextResponse } from 'next/server'
-import { findSessionJSONL } from '@/lib/claude-reader'
-import { parseSessionReplay } from '@/lib/replay-parser'
+import { NextResponse } from "next/server";
+import { findSessionJSONL } from "@/lib/claude-reader";
+import { parseSessionReplay } from "@/lib/replay-parser";
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic";
 
 export async function GET(
   _req: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params
-  const jsonlPath = await findSessionJSONL(id)
+  const { id } = await params;
+  if (/[/\\]/.test(id) || /\.\./.test(id)) {
+    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
+  }
+  const jsonlPath = await findSessionJSONL(id);
 
   if (!jsonlPath) {
-    return NextResponse.json({ error: 'Session JSONL not found' }, { status: 404 })
+    return NextResponse.json(
+      { error: "Session JSONL not found" },
+      { status: 404 },
+    );
   }
 
-  const replay = await parseSessionReplay(jsonlPath, id)
-  return NextResponse.json(replay)
+  const replay = await parseSessionReplay(jsonlPath, id);
+  return NextResponse.json(replay);
 }

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -9,6 +9,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
+  if (/[/\\]/.test(id) || /\.\./.test(id)) {
+    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
+  }
   const [meta, facet] = await Promise.all([readSessionMeta(id), readFacet(id)]);
 
   // readSessionMeta only finds session-meta/*.json files (legacy path).

--- a/app/overview-client.tsx
+++ b/app/overview-client.tsx
@@ -120,7 +120,8 @@ export function OverviewClient() {
   const dateFrom = useMemo(() => {
     if (dateFromOverride) return dateFromOverride;
     if (data?.computed?.firstSessionDate) {
-      return format(new Date(data.computed.firstSessionDate), "MM/dd/yyyy");
+      const d = new Date(data.computed.firstSessionDate);
+      if (!isNaN(d.getTime())) return format(d, "MM/dd/yyyy");
     }
     return format(subDays(new Date(), 7), "MM/dd/yyyy");
   }, [dateFromOverride, data?.computed?.firstSessionDate]);

--- a/lib/readers/projects.ts
+++ b/lib/readers/projects.ts
@@ -64,7 +64,8 @@ export async function resolveProjectPath(slug: string): Promise<string> {
     const firstLine = raw.split(/\r?\n/).find(Boolean);
     if (firstLine) {
       const obj = JSON.parse(firstLine) as { cwd?: string };
-      if (obj.cwd) return obj.cwd;
+      if (obj.cwd && path.isAbsolute(obj.cwd) && !obj.cwd.includes(".."))
+        return obj.cwd;
     }
   } catch {
     // Fall through to slug-based path

--- a/lib/readers/sessions.ts
+++ b/lib/readers/sessions.ts
@@ -304,12 +304,13 @@ export async function readSessionMeta(
   }
 }
 
-/** Get sessions: prefers JSONL, falls back to usage-data/session-meta */
+/** Get sessions: returns the larger of JSONL-derived and session-meta sets.
+ *  Prevents oscillation when readSessionsFromProjectJSONL() transiently
+ *  returns [] due to fs errors (catch-all at line 261). */
 export async function getSessions(): Promise<SessionMeta[]> {
   const [jsonl, meta] = await Promise.all([
     readSessionsFromProjectJSONL(),
     readAllSessionMeta(),
   ]);
-  if (jsonl.length > 0) return jsonl;
-  return meta;
+  return jsonl.length >= meta.length ? jsonl : meta;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,12 @@ const nextConfig: NextConfig = {
         { key: "X-Frame-Options", value: "DENY" },
         { key: "X-Content-Type-Options", value: "nosniff" },
         { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        {
+          key: "Content-Security-Policy",
+          // unsafe-inline + unsafe-eval needed for Next.js dev mode + Recharts
+          value:
+            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:",
+        },
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- `getSessions()` returns larger of JSONL/meta sets — prevents 1979/389 oscillation
- `resolveProjectPath` validates cwd: must be absolute, no `..`
- Session `[id]` and replay routes reject path traversal
- Add Content-Security-Policy header
- `security-paths.test.ts` imports `isValidSlug` from production code
- Guard `firstSessionDate=""` → Invalid Date in overview

Closes #62

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 109/109 pass
- [ ] CI passes