### PR TITLE
fix: QA round 6 — catch-all warning, E2E timeout, shared isValidSlug

### DIFF
--- a/__tests__/get-sessions.test.ts
+++ b/__tests__/get-sessions.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import type { SessionMeta } from "@/types/claude";
+
+/**
+ * Test the getSessions selection logic directly — the "return larger set"
+ * oscillation prevention from #62. We test the logic, not the IO functions.
+ */
+
+function mockSession(id: string): SessionMeta {
+  return {
+    session_id: id,
+    project_path: "/test",
+    start_time: "2026-04-01T10:00:00Z",
+    duration_minutes: 30,
+    model: "claude-sonnet-4-6",
+    user_message_count: 5,
+    assistant_message_count: 5,
+    tool_counts: {},
+    languages: {},
+    git_commits: 0,
+    git_pushes: 0,
+    input_tokens: 1000,
+    output_tokens: 500,
+    first_prompt: "test",
+    user_interruptions: 0,
+    user_response_times: [],
+    tool_errors: 0,
+    tool_error_categories: {},
+    uses_task_agent: false,
+    uses_mcp: false,
+    uses_web_search: false,
+    uses_web_fetch: false,
+    lines_added: 0,
+    lines_removed: 0,
+    files_modified: 0,
+    message_hours: [],
+    user_message_timestamps: [],
+  };
+}
+
+// Replicate the getSessions selection logic
+function selectSessions(
+  jsonl: SessionMeta[],
+  meta: SessionMeta[],
+): SessionMeta[] {
+  return jsonl.length >= meta.length ? jsonl : meta;
+}
+
+describe("getSessions — oscillation prevention logic", () => {
+  it("returns JSONL when JSONL has more sessions", () => {
+    const jsonl = [mockSession("s1"), mockSession("s2")];
+    const meta = [mockSession("s1")];
+    expect(selectSessions(jsonl, meta)).toBe(jsonl);
+  });
+
+  it("returns meta when JSONL fails (returns empty)", () => {
+    const jsonl: SessionMeta[] = [];
+    const meta = [mockSession("s1"), mockSession("s2"), mockSession("s3")];
+    expect(selectSessions(jsonl, meta)).toBe(meta);
+    expect(selectSessions(jsonl, meta)).toHaveLength(3);
+  });
+
+  it("returns empty when both sources return empty", () => {
+    expect(selectSessions([], [])).toEqual([]);
+  });
+
+  it("prefers JSONL when both have equal length", () => {
+    const jsonl = [mockSession("jsonl-1")];
+    const meta = [mockSession("meta-1")];
+    const result = selectSessions(jsonl, meta);
+    expect(result).toBe(jsonl);
+    expect(result[0].session_id).toBe("jsonl-1");
+  });
+});

--- a/app/api/projects/[slug]/route.ts
+++ b/app/api/projects/[slug]/route.ts
@@ -5,6 +5,7 @@ import {
   listProjectJSONLFiles,
   readJSONLLines,
   resolveProjectPath,
+  isValidSlug,
 } from "@/lib/claude-reader";
 import { estimateCostFromUsage } from "@/lib/pricing";
 import { projectDisplayName } from "@/lib/decode";
@@ -20,7 +21,7 @@ export async function GET(
   { params }: { params: Promise<{ slug: string }> },
 ) {
   const { slug } = await params;
-  if (/[/\\]/.test(slug) || /\.\./.test(slug)) {
+  if (!isValidSlug(slug)) {
     return NextResponse.json({ error: "Invalid slug" }, { status: 400 });
   }
   const projectPath = await resolveProjectPath(slug);

--- a/app/api/sessions/[id]/replay/route.ts
+++ b/app/api/sessions/[id]/replay/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { findSessionJSONL } from "@/lib/claude-reader";
+import { findSessionJSONL, isValidSlug } from "@/lib/claude-reader";
 import { parseSessionReplay } from "@/lib/replay-parser";
 
 export const dynamic = "force-dynamic";
@@ -9,8 +9,13 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  if (/[/\\]/.test(id) || /\.\./.test(id)) {
-    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
+  if (!isValidSlug(id)) {
+    return NextResponse.json(
+      {
+        error: "Invalid session ID — must not contain path separators or '..'",
+      },
+      { status: 400 },
+    );
   }
   const jsonlPath = await findSessionJSONL(id);
 

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
-import { readSessionMeta, readFacet, getSessions } from "@/lib/claude-reader";
+import {
+  readSessionMeta,
+  readFacet,
+  getSessions,
+  isValidSlug,
+} from "@/lib/claude-reader";
 import { estimateCostFromUsage } from "@/lib/pricing";
 
 export const dynamic = "force-dynamic";
@@ -9,8 +14,13 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  if (/[/\\]/.test(id) || /\.\./.test(id)) {
-    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
+  if (!isValidSlug(id)) {
+    return NextResponse.json(
+      {
+        error: "Invalid session ID — must not contain path separators or '..'",
+      },
+      { status: 400 },
+    );
   }
   const [meta, facet] = await Promise.all([readSessionMeta(id), readFacet(id)]);
 

--- a/lib/readers/index.ts
+++ b/lib/readers/index.ts
@@ -8,6 +8,7 @@ export {
   resolveProjectPath,
   findSessionSlug,
   findSessionJSONL,
+  isValidSlug,
 } from "./projects";
 export {
   deriveSessionMetaFromJSONL,

--- a/lib/readers/sessions.ts
+++ b/lib/readers/sessions.ts
@@ -258,7 +258,10 @@ export async function readSessionsFromProjectJSONL(): Promise<SessionMeta[]> {
       (a, b) =>
         new Date(b.start_time).getTime() - new Date(a.start_time).getTime(),
     );
-  } catch {
+  } catch (err) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[cc-lens] readSessionsFromProjectJSONL failed:", err);
+    }
     return [];
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,7 +22,7 @@ const nextConfig: NextConfig = {
           key: "Content-Security-Policy",
           // unsafe-inline + unsafe-eval needed for Next.js dev mode + Recharts
           value:
-            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:",
+            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; frame-ancestors 'none'",
         },
       ],
     },

--- a/scripts/e2e-test.mjs
+++ b/scripts/e2e-test.mjs
@@ -58,10 +58,10 @@ try {
   console.log("1. Overview Page");
   const overview = await context.newPage();
   await overview.goto(BASE, { waitUntil: "load", timeout: 15000 });
-  // Wait for actual data instead of fixed timeout (cold start can take >3s)
+  // Wait for actual data — 30s accommodates Turbopack cold compile + SSR + SWR fetch
   await overview.waitForFunction(
     () => document.body.textContent.includes("conversations"),
-    { timeout: 15000 },
+    { timeout: 30000 },
   );
 
   await test("page loads with title", async () => {


### PR DESCRIPTION
## Summary
- Dev-mode warning in `readSessionsFromProjectJSONL` catch block (was silent)
- E2E timeout 15s → 30s for cold start reliability
- 4 new tests for getSessions oscillation prevention logic
- Error messages include "must not contain path separators or '..'"
- CSP `frame-ancestors 'none'` added
- `isValidSlug` exported from barrel, inline regex replaced in 3 routes

Closes #68

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 113/113 pass
- [ ] CI passes