### PR TITLE
fix: session oscillation root cause — promise deduplication

### DIFF
--- a/app/api/projects/[slug]/route.ts
+++ b/app/api/projects/[slug]/route.ts
@@ -22,7 +22,13 @@ export async function GET(
 ) {
   const { slug } = await params;
   if (!isValidSlug(slug)) {
-    return NextResponse.json({ error: "Invalid slug" }, { status: 400 });
+    return NextResponse.json(
+      {
+        error:
+          "Invalid project slug — must not contain path separators or '..'",
+      },
+      { status: 400 },
+    );
   }
   const projectPath = await resolveProjectPath(slug);
   const allSessions = await getSessions();

--- a/lib/readers/sessions.ts
+++ b/lib/readers/sessions.ts
@@ -259,9 +259,8 @@ export async function readSessionsFromProjectJSONL(): Promise<SessionMeta[]> {
         new Date(b.start_time).getTime() - new Date(a.start_time).getTime(),
     );
   } catch (err) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[cc-lens] readSessionsFromProjectJSONL failed:", err);
-    }
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[cc-lens] readSessionsFromProjectJSONL failed:", msg);
     return [];
   }
 }
@@ -307,10 +306,24 @@ export async function readSessionMeta(
   }
 }
 
-/** Get sessions: returns the larger of JSONL-derived and session-meta sets.
- *  Prevents oscillation when readSessionsFromProjectJSONL() transiently
- *  returns [] due to fs errors (catch-all at line 261). */
-export async function getSessions(): Promise<SessionMeta[]> {
+/** In-flight promise deduplication — all concurrent callers within 100ms
+ *  share the same promise, preventing cache race conditions when multiple
+ *  API routes call getSessions() simultaneously on page load. */
+let _sessionsPromise: Promise<SessionMeta[]> | null = null;
+
+export function getSessions(): Promise<SessionMeta[]> {
+  if (!_sessionsPromise) {
+    _sessionsPromise = _getSessionsImpl();
+    _sessionsPromise.finally(() => {
+      setTimeout(() => {
+        _sessionsPromise = null;
+      }, 100);
+    });
+  }
+  return _sessionsPromise;
+}
+
+async function _getSessionsImpl(): Promise<SessionMeta[]> {
   const [jsonl, meta] = await Promise.all([
     readSessionsFromProjectJSONL(),
     readAllSessionMeta(),


### PR DESCRIPTION
## Summary
- `getSessions()` now uses in-flight promise deduplication (100ms TTL)
- All 9 concurrent API callers share one promise — no cache race
- `readSessionsFromProjectJSONL` catch block always logs `console.error`
- Slug route error message aligned: "must not contain path separators or '..'"

Closes #70, Closes #71

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 113/113 pass
- [ ] CI passes