### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to cc-lens are documented here. This project follows [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.4.4] — 2026-04-06
+
+### Changed
+
+- **CLI uses `next build` + `next start` instead of `next dev`** — saves 1.5GB RAM (#78)
+  - RAM: 1,840 MB → ~300 MB
+  - CPU idle: ~100% → ~0%
+  - First page load: 2-5s → <0.5s
+  - Build runs once per version (~30-60s), then `next start` for all subsequent runs
+  - `--dev` flag available for contributors who need HMR
+
 ## [0.4.3] — 2026-04-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Visualize your token usage, costs, sessions, and projects — all from `~/.claude/`.\
 Zero cloud. Zero telemetry. Your data never leaves your machine.
 
-[![Version](https://img.shields.io/badge/version-0.4.3-orange)](https://github.com/pitimon/cc-lens/releases/tag/v0.4.3)
+[![Version](https://img.shields.io/badge/version-0.4.4-orange)](https://github.com/pitimon/cc-lens/releases/tag/v0.4.4)
 [![CI](https://github.com/pitimon/cc-lens/actions/workflows/ci.yml/badge.svg)](https://github.com/pitimon/cc-lens/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-lens",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-lens",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-lens",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Claude Code Lens — visualize your usage, costs, and sessions from ~/.claude/",
   "author": "pitimon (https://github.com/pitimon)",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Version bump to 0.4.4 + CHANGELOG + README badge.

Key: CLI uses `next build` + `next start` instead of `next dev` — saves 1.5GB RAM (#78).

## Test plan
- [x] 113/113 tests pass
- [ ] CI passes → merge → tag → release