### PR TITLE
chore: release v0.5.0 — standalone output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to cc-lens are documented here. This project follows [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.5.0] — 2026-04-06
+
+### Changed
+
+- **Standalone output mode** — `output: "standalone"` generates minimal `server.js` with only required deps bundled (#81)
+  - RAM: ~1,047 MB → ~300 MB (3.5x reduction)
+  - CPU idle: ~100% → ~15% (Next.js 15-16 regression mitigated)
+  - Disk: 531 MB → ~100 MB (node_modules no longer needed at runtime)
+  - `optimizePackageImports` for recharts, lucide-react, date-fns
+  - `webpackMemoryOptimizations` enabled
+  - Static assets (`public/`, `.next/static/`) copied into standalone post-build
+  - Graceful fallback to `next dev` if standalone unavailable
+- **CLI production mode** — `next build` + standalone `server.js` instead of `next dev` (#78)
+  - Build once per version (~30-60s), then instant start on subsequent runs
+  - `--dev` flag for contributors who need HMR
+
 ## [0.4.4] — 2026-04-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Visualize your token usage, costs, sessions, and projects — all from `~/.claude/`.\
 Zero cloud. Zero telemetry. Your data never leaves your machine.
 
-[![Version](https://img.shields.io/badge/version-0.4.4-orange)](https://github.com/pitimon/cc-lens/releases/tag/v0.4.4)
+[![Version](https://img.shields.io/badge/version-0.5.0-orange)](https://github.com/pitimon/cc-lens/releases/tag/v0.5.0)
 [![CI](https://github.com/pitimon/cc-lens/actions/workflows/ci.yml/badge.svg)](https://github.com/pitimon/cc-lens/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-lens",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-lens",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-lens",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Claude Code Lens — visualize your usage, costs, and sessions from ~/.claude/",
   "author": "pitimon (https://github.com/pitimon)",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Version bump to 0.5.0 (minor — architecture change) + CHANGELOG + README badge.

Key: standalone output mode — RAM 1GB → ~300MB, disk 531MB → ~100MB.

## Test plan
- [x] 113/113 tests pass
- [ ] CI passes → merge → tag → release