### PR TITLE
docs: add architecture talk YouTube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Zero cloud. Zero telemetry. Your data never leaves your machine.
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 [![Demo Video](https://img.shields.io/badge/Demo-YouTube-red?logo=youtube)](https://www.youtube.com/watch?v=F01R99FeB5U)
+[![Architecture Talk](https://img.shields.io/badge/Architecture-YouTube-red?logo=youtube)](https://www.youtube.com/watch?v=9bG1WyOpLFM)
 
 </div>
 

--- a/docs/8-HABIT-QA-SUMMARY.md
+++ b/docs/8-HABIT-QA-SUMMARY.md
@@ -120,3 +120,8 @@ Score dipped at rounds 3 and 5 because deeper scanning uncovered more issues —
 ---
 
 _QA performed by Claude Code (Opus 4.6) with 8-Habit AI Dev framework_
+
+## External Knowledge Sharing
+
+- [Architecture Talk (YouTube)](https://www.youtube.com/watch?v=9bG1WyOpLFM) — cc-lens architecture, 8-Habit development process, and QA journey
+- [Demo Video (YouTube)](https://www.youtube.com/watch?v=F01R99FeB5U) — dashboard walkthrough


### PR DESCRIPTION
## Summary
- README: Architecture Talk YouTube badge added alongside Demo badge
- 8-HABIT-QA-SUMMARY.md: External Knowledge Sharing section with both video links
- Issue #96 closed as completed

## Test plan
- [x] Documentation only — no code changes
- [ ] CI passes