### PR TITLE
fix: Escape key + axe-core wiring + mutation debt tracking

### DIFF
--- a/components/onboarding/welcome-overlay.tsx
+++ b/components/onboarding/welcome-overlay.tsx
@@ -32,6 +32,9 @@ export function WelcomeOverlay() {
       role="dialog"
       aria-modal="true"
       aria-label="Welcome to cc-lens"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") dismiss();
+      }}
     >
       <div className="bg-card border border-border rounded-xl shadow-2xl max-w-md mx-4 p-8 space-y-5">
         <h2 className="text-xl font-bold text-foreground font-mono">

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -28,7 +28,7 @@ cc-lens targets WCAG 2.1 Level A compliance for a localhost developer tool.
 
 ### Automated
 
-Install `@axe-core/playwright` and run:
+`@axe-core/playwright` is wired into the E2E test suite. Run:
 
 ```bash
 node scripts/e2e-test.mjs  # includes axe scan on overview page

--- a/scripts/e2e-test.mjs
+++ b/scripts/e2e-test.mjs
@@ -8,6 +8,7 @@
  */
 
 import { chromium } from "playwright";
+import AxeBuilder from "@axe-core/playwright";
 
 const PORT = process.argv.includes("--port")
   ? process.argv[process.argv.indexOf("--port") + 1]
@@ -84,6 +85,16 @@ try {
     // Should show M (millions) not B (billions) for token count
     if (text.includes("16.9B"))
       throw new Error("Token count still shows inflated 16.9B");
+  });
+
+  await test("no critical a11y violations (axe-core)", async () => {
+    const results = await new AxeBuilder({ page: overview }).analyze();
+    const critical = results.violations.filter((v) => v.impact === "critical");
+    if (critical.length > 0) {
+      throw new Error(
+        `${critical.length} critical a11y violations: ${critical.map((v) => v.id).join(", ")}`,
+      );
+    }
   });
 
   await test("Star on GitHub links to pitimon/cc-lens", async () => {


### PR DESCRIPTION
## Summary
- WelcomeOverlay: `onKeyDown` Escape dismissal (WCAG 2.1 SC 2.1.2)
- E2E: axe-core now actually wired — `AxeBuilder` scan on overview page
- `docs/accessibility.md` updated from claim to reality
- Filed backlog: #108 (cache mutation), #109 (CSP unsafe-eval), #110 (rate limiting)

Closes #107

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 119/119 pass
- [ ] CI passes
- [ ] Manual: Escape dismisses overlay