### PR TITLE
ux: group sidebar into 4 sections — Miller's Law (7±2)

### DIFF
--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -23,19 +23,40 @@ import {
 } from "lucide-react";
 import { useTheme } from "@/components/theme-provider";
 
-const NAV = [
-  { href: "/", label: "overview", icon: LayoutDashboard },
-  { href: "/projects", label: "projects", icon: FolderOpen },
-  { href: "/sessions", label: "sessions", icon: MessageSquare },
-  { href: "/costs", label: "costs", icon: DollarSign },
-  { href: "/tools", label: "tools", icon: Wrench },
-  { href: "/activity", label: "activity", icon: Activity },
-  { href: "/history", label: "history", icon: History },
-  { href: "/todos", label: "todos", icon: ListTodo },
-  { href: "/plans", label: "plans", icon: FileText },
-  { href: "/memory", label: "memory", icon: Brain },
-  { href: "/settings", label: "settings", icon: Settings },
-  { href: "/export", label: "export", icon: Download },
+// Grouped navigation — Miller's Law (7±2): 4 groups instead of 12 flat items
+const NAV_GROUPS = [
+  {
+    label: "Analytics",
+    items: [
+      { href: "/", label: "overview", icon: LayoutDashboard },
+      { href: "/costs", label: "costs", icon: DollarSign },
+      { href: "/activity", label: "activity", icon: Activity },
+      { href: "/history", label: "history", icon: History },
+    ],
+  },
+  {
+    label: "Workspace",
+    items: [
+      { href: "/projects", label: "projects", icon: FolderOpen },
+      { href: "/sessions", label: "sessions", icon: MessageSquare },
+      { href: "/tools", label: "tools", icon: Wrench },
+      { href: "/memory", label: "memory", icon: Brain },
+    ],
+  },
+  {
+    label: "Planning",
+    items: [
+      { href: "/plans", label: "plans", icon: FileText },
+      { href: "/todos", label: "todos", icon: ListTodo },
+    ],
+  },
+  {
+    label: "System",
+    items: [
+      { href: "/settings", label: "settings", icon: Settings },
+      { href: "/export", label: "export", icon: Download },
+    ],
+  },
 ];
 
 const STORAGE_KEY = "cc-lens-sidebar";
@@ -95,34 +116,45 @@ export function Sidebar() {
         </button>
       </div>
 
-      <nav className="flex-1 px-2 py-5 space-y-0.5 overflow-y-auto">
-        {NAV.map(({ href, label, icon: Icon }) => {
-          const active = pathname === href;
-          return (
-            <Link
-              key={href}
-              href={href}
-              title={collapsed ? label : undefined}
-              className={[
-                "flex items-center gap-2.5 rounded-r text-base font-mono transition-colors relative",
-                collapsed ? "justify-center px-2 py-3" : "px-4 py-3",
-                active
-                  ? "text-sidebar-primary bg-sidebar-accent border-l-2 border-l-sidebar-primary"
-                  : "text-sidebar-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent/80",
-              ].join(" ")}
-            >
-              <Icon
-                className={[
-                  "w-4 h-4 shrink-0",
-                  active
-                    ? "text-sidebar-primary"
-                    : "text-sidebar-foreground/40",
-                ].join(" ")}
-              />
-              {!collapsed && label}
-            </Link>
-          );
-        })}
+      <nav className="flex-1 px-2 py-3 overflow-y-auto">
+        {NAV_GROUPS.map((group) => (
+          <div key={group.label} className="mb-3">
+            {!collapsed && (
+              <p className="px-4 mb-1 text-[10px] font-mono uppercase tracking-widest text-sidebar-foreground/30">
+                {group.label}
+              </p>
+            )}
+            <div className="space-y-0.5">
+              {group.items.map(({ href, label, icon: Icon }) => {
+                const active = pathname === href;
+                return (
+                  <Link
+                    key={href}
+                    href={href}
+                    title={collapsed ? label : undefined}
+                    className={[
+                      "flex items-center gap-2.5 rounded-r text-base font-mono transition-colors relative",
+                      collapsed ? "justify-center px-2 py-3" : "px-4 py-3",
+                      active
+                        ? "text-sidebar-primary bg-sidebar-accent border-l-2 border-l-sidebar-primary"
+                        : "text-sidebar-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent/80",
+                    ].join(" ")}
+                  >
+                    <Icon
+                      className={[
+                        "w-4 h-4 shrink-0",
+                        active
+                          ? "text-sidebar-primary"
+                          : "text-sidebar-foreground/40",
+                      ].join(" ")}
+                    />
+                    {!collapsed && label}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </nav>
 
       <div className="px-3 py-4 border-t border-sidebar-border flex items-center justify-between">


### PR DESCRIPTION
## Summary
12 flat nav items → 4 semantic groups (Analytics, Workspace, Planning, System).

Group headers visible in expanded mode. Collapsed mode unchanged (icons only). Active highlight works. All 12 routes accessible.

Based on: [Miller's Law](https://lawsofux.com/millers-law/), [Airbnb DLS](https://principles.design/examples/airbnb-design-principles), [Google PAIR](https://pair.withgoogle.com/guidebook/).

Closes #112 | Milestone: M8

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 119/119 pass
- [ ] CI passes
- [ ] Visual: sidebar shows 4 labeled groups
- [ ] Visual: collapsed mode shows icons only (no group labels)