### PR TITLE
a11y: chart colors → CSS variables, dark mode contrast improved

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,46 +5,86 @@
 
 @theme inline {
   @keyframes accordion-down {
-    from { height: 0; }
-    to { height: var(--radix-accordion-content-height, var(--accordion-panel-height, auto)); }
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-accordion-content-height,
+        var(--accordion-panel-height, auto)
+      );
+    }
   }
   @keyframes accordion-up {
-    from { height: var(--radix-accordion-content-height, var(--accordion-panel-height, auto)); }
-    to { height: 0; }
+    from {
+      height: var(
+        --radix-accordion-content-height,
+        var(--accordion-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
   }
 }
 
 @custom-variant data-open {
-  &:where([data-state="open"]), &:where([data-open]:not([data-open="false"])) { @slot; }
+  &:where([data-state="open"]),
+  &:where([data-open]:not([data-open="false"])) {
+    @slot;
+  }
 }
 @custom-variant data-closed {
-  &:where([data-state="closed"]), &:where([data-closed]:not([data-closed="false"])) { @slot; }
+  &:where([data-state="closed"]),
+  &:where([data-closed]:not([data-closed="false"])) {
+    @slot;
+  }
 }
 @custom-variant data-checked {
-  &:where([data-state="checked"]), &:where([data-checked]:not([data-checked="false"])) { @slot; }
+  &:where([data-state="checked"]),
+  &:where([data-checked]:not([data-checked="false"])) {
+    @slot;
+  }
 }
 @custom-variant data-unchecked {
-  &:where([data-state="unchecked"]), &:where([data-unchecked]:not([data-unchecked="false"])) { @slot; }
+  &:where([data-state="unchecked"]),
+  &:where([data-unchecked]:not([data-unchecked="false"])) {
+    @slot;
+  }
 }
 @custom-variant data-selected {
-  &:where([data-selected="true"]) { @slot; }
+  &:where([data-selected="true"]) {
+    @slot;
+  }
 }
 @custom-variant data-disabled {
-  &:where([data-disabled="true"]), &:where([data-disabled]:not([data-disabled="false"])) { @slot; }
+  &:where([data-disabled="true"]),
+  &:where([data-disabled]:not([data-disabled="false"])) {
+    @slot;
+  }
 }
 @custom-variant data-active {
-  &:where([data-state="active"]), &:where([data-active]:not([data-active="false"])) { @slot; }
+  &:where([data-state="active"]),
+  &:where([data-active]:not([data-active="false"])) {
+    @slot;
+  }
 }
 @custom-variant data-horizontal {
-  &:where([data-orientation="horizontal"]) { @slot; }
+  &:where([data-orientation="horizontal"]) {
+    @slot;
+  }
 }
 @custom-variant data-vertical {
-  &:where([data-orientation="vertical"]) { @slot; }
+  &:where([data-orientation="vertical"]) {
+    @slot;
+  }
 }
 @utility no-scrollbar {
   -ms-overflow-style: none;
   scrollbar-width: none;
-  &::-webkit-scrollbar { display: none; }
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 @theme inline {
@@ -155,7 +195,7 @@
   --border: #262a36;
   --input: #1e212b;
   --ring: #d97706;
-  --chart-1: #d97706;
+  --chart-1: #f59e0b;
   --chart-2: #34d399;
   --chart-3: #60a5fa;
   --chart-4: #a78bfa;
@@ -176,7 +216,9 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-geist-mono), "JetBrains Mono", "Fira Code", "Consolas", monospace;
+    font-family:
+      var(--font-geist-mono), "JetBrains Mono", "Fira Code", "Consolas",
+      monospace;
     font-size: 15px;
   }
 }

--- a/app/overview-client.tsx
+++ b/app/overview-client.tsx
@@ -182,19 +182,27 @@ export function OverviewClient() {
     computed.totalCacheReadTokens + computed.totalCacheWriteTokens;
 
   const ioSegs = [
-    { label: "input", value: computed.totalInputTokens, color: "#60a5fa" },
-    { label: "output", value: computed.totalOutputTokens, color: "#d97706" },
+    {
+      label: "input",
+      value: computed.totalInputTokens,
+      color: "var(--chart-3)",
+    },
+    {
+      label: "output",
+      value: computed.totalOutputTokens,
+      color: "var(--chart-1)",
+    },
   ];
   const cacheSegs = [
     {
       label: "cache_read",
       value: computed.totalCacheReadTokens,
-      color: "#34d399",
+      color: "var(--chart-2)",
     },
     {
       label: "cache_write",
       value: computed.totalCacheWriteTokens,
-      color: "#a78bfa",
+      color: "var(--chart-4)",
     },
   ];
   const tokenSegs = [...ioSegs, ...cacheSegs];

--- a/components/costs/cache-efficiency-panel.tsx
+++ b/components/costs/cache-efficiency-panel.tsx
@@ -1,76 +1,98 @@
-import { formatCost, formatPct, formatTokens } from '@/lib/decode'
-import type { ModelCostBreakdown } from '@/types/claude'
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts'
+import { formatCost, formatPct, formatTokens } from "@/lib/decode";
+import type { ModelCostBreakdown } from "@/types/claude";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
 
 interface Props {
-  models: ModelCostBreakdown[]
-  totalSavings: number
+  models: ModelCostBreakdown[];
+  totalSavings: number;
 }
 
 export function CacheEfficiencyPanel({ models, totalSavings }: Props) {
-  const totalCacheRead = models.reduce((s, m) => s + m.cache_read_tokens, 0)
-  const totalInput     = models.reduce((s, m) => s + m.input_tokens, 0)
-  const totalContext   = totalInput + totalCacheRead
-  const hitRate        = totalContext > 0 ? totalCacheRead / totalContext : 0
-  const totalCost      = models.reduce((s, m) => s + m.estimated_cost, 0)
-  const wouldHavePaid  = totalCost + totalSavings
+  const totalCacheRead = models.reduce((s, m) => s + m.cache_read_tokens, 0);
+  const totalInput = models.reduce((s, m) => s + m.input_tokens, 0);
+  const totalContext = totalInput + totalCacheRead;
+  const hitRate = totalContext > 0 ? totalCacheRead / totalContext : 0;
+  const totalCost = models.reduce((s, m) => s + m.estimated_cost, 0);
+  const wouldHavePaid = totalCost + totalSavings;
 
   const pieData = [
-    { name: 'Cache Read', value: totalCacheRead, color: '#34d399' },
-    { name: 'Direct Input', value: totalInput, color: '#60a5fa' },
-  ]
+    { name: "Cache Read", value: totalCacheRead, color: "var(--chart-2)" },
+    { name: "Direct Input", value: totalInput, color: "var(--chart-3)" },
+  ];
 
   return (
     <div className="grid grid-cols-[1fr_160px] gap-4 items-start">
       <div className="space-y-2 text-[13px]">
         <div className="flex items-center justify-between">
           <span className="text-muted-foreground">Cache hit rate</span>
-          <span className="text-[#34d399] font-bold text-lg">{(hitRate * 100).toFixed(1)}%</span>
+          <span className="text-[#34d399] font-bold text-lg">
+            {(hitRate * 100).toFixed(1)}%
+          </span>
         </div>
         <div className="flex items-center justify-between">
           <span className="text-muted-foreground">Context from cache</span>
-          <span className="text-foreground font-mono">{formatTokens(totalCacheRead)}</span>
+          <span className="text-foreground font-mono">
+            {formatTokens(totalCacheRead)}
+          </span>
         </div>
         <div className="flex items-center justify-between">
           <span className="text-muted-foreground">Context from input</span>
-          <span className="text-foreground font-mono">{formatTokens(totalInput)}</span>
+          <span className="text-foreground font-mono">
+            {formatTokens(totalInput)}
+          </span>
         </div>
         <div className="border-t border-border/50 pt-2 mt-2 space-y-1.5">
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground">Without cache</span>
-            <span className="text-red-400 font-mono">{formatCost(wouldHavePaid)}</span>
+            <span className="text-red-400 font-mono">
+              {formatCost(wouldHavePaid)}
+            </span>
           </div>
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground">You paid</span>
-            <span className="text-foreground font-mono">{formatCost(totalCost)}</span>
+            <span className="text-foreground font-mono">
+              {formatCost(totalCost)}
+            </span>
           </div>
           <div className="flex items-center justify-between font-bold">
             <span className="text-[#34d399]">Savings</span>
-            <span className="text-[#34d399] font-mono">{formatCost(totalSavings)}</span>
+            <span className="text-[#34d399] font-mono">
+              {formatCost(totalSavings)}
+            </span>
           </div>
         </div>
       </div>
-      <div role="img" aria-label="Cache efficiency chart"><ResponsiveContainer width="100%" height={140}>
-        <PieChart>
-          <Pie
-            data={pieData}
-            cx="50%"
-            cy="50%"
-            innerRadius={35}
-            outerRadius={60}
-            dataKey="value"
-            strokeWidth={0}
-          >
-            {pieData.map((entry, i) => (
-              <Cell key={i} fill={entry.color} />
-            ))}
-          </Pie>
-          <Tooltip
-            contentStyle={{ background: 'var(--card)', border: '1px solid var(--border)', borderRadius: 4, fontSize: 12 }}
-            formatter={(val: number | undefined, name?: string) => [formatTokens(val ?? 0), name ?? '']}
-          />
-        </PieChart>
-      </ResponsiveContainer></div>
+      <div role="img" aria-label="Cache efficiency chart">
+        <ResponsiveContainer width="100%" height={140}>
+          <PieChart>
+            <Pie
+              data={pieData}
+              cx="50%"
+              cy="50%"
+              innerRadius={35}
+              outerRadius={60}
+              dataKey="value"
+              strokeWidth={0}
+            >
+              {pieData.map((entry, i) => (
+                <Cell key={i} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip
+              contentStyle={{
+                background: "var(--card)",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                fontSize: 12,
+              }}
+              formatter={(val: number | undefined, name?: string) => [
+                formatTokens(val ?? 0),
+                name ?? "",
+              ]}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
     </div>
-  )
+  );
 }

--- a/components/costs/cost-over-time-chart.tsx
+++ b/components/costs/cost-over-time-chart.tsx
@@ -15,10 +15,10 @@ import { filterDailyByWindow } from "@/lib/costs-compute";
 import type { DailyCost, HourlyCost } from "@/types/claude";
 
 const MODEL_COLORS: Record<string, string> = {
-  "claude-opus-4-6": "#d97706",
-  "claude-opus-4-5-20251101": "#a78bfa",
-  "claude-sonnet-4-6": "#60a5fa",
-  "claude-haiku-4-5": "#34d399",
+  "claude-opus-4-6": "var(--chart-1)",
+  "claude-opus-4-5-20251101": "var(--chart-4)",
+  "claude-sonnet-4-6": "var(--chart-3)",
+  "claude-haiku-4-5": "var(--chart-2)",
 };
 
 function colorForModel(m: string): string {
@@ -110,51 +110,53 @@ export function CostOverTimeChart({
           No data for this period
         </p>
       ) : (
-        <div role="img" aria-label="Cost over time chart"><ResponsiveContainer width="100%" height={200}>
-          <AreaChart
-            data={data}
-            margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
-          >
-            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-            <XAxis
-              dataKey={xKey}
-              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
-              tickLine={false}
-              axisLine={false}
-              interval="preserveStartEnd"
-            />
-            <YAxis
-              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
-              tickLine={false}
-              axisLine={false}
-              tickFormatter={(v) => `$${v.toFixed(2)}`}
-              width={48}
-            />
-            <Tooltip
-              contentStyle={{
-                background: "var(--card)",
-                border: "1px solid var(--border)",
-                borderRadius: 4,
-                fontSize: 12,
-              }}
-              formatter={(val: number | undefined, name?: string) => [
-                formatCost(val ?? 0),
-                shortModel(name ?? ""),
-              ]}
-            />
-            {models.map((m) => (
-              <Area
-                key={m}
-                type="monotone"
-                dataKey={m}
-                stackId="1"
-                stroke={colorForModel(m)}
-                fill={colorForModel(m) + "30"}
-                strokeWidth={1.5}
+        <div role="img" aria-label="Cost over time chart">
+          <ResponsiveContainer width="100%" height={200}>
+            <AreaChart
+              data={data}
+              margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+              <XAxis
+                dataKey={xKey}
+                tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+                tickLine={false}
+                axisLine={false}
+                interval="preserveStartEnd"
               />
-            ))}
-          </AreaChart>
-        </ResponsiveContainer></div>
+              <YAxis
+                tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(v) => `$${v.toFixed(2)}`}
+                width={48}
+              />
+              <Tooltip
+                contentStyle={{
+                  background: "var(--card)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 4,
+                  fontSize: 12,
+                }}
+                formatter={(val: number | undefined, name?: string) => [
+                  formatCost(val ?? 0),
+                  shortModel(name ?? ""),
+                ]}
+              />
+              {models.map((m) => (
+                <Area
+                  key={m}
+                  type="monotone"
+                  dataKey={m}
+                  stackId="1"
+                  stroke={colorForModel(m)}
+                  fill={colorForModel(m) + "30"}
+                  strokeWidth={1.5}
+                />
+              ))}
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
       )}
     </div>
   );

--- a/components/overview/model-breakdown-donut.tsx
+++ b/components/overview/model-breakdown-donut.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 
 import {
   PieChart,
@@ -7,89 +7,97 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
-} from 'recharts'
-import type { ModelUsage } from '@/types/claude'
-import { formatTokens } from '@/lib/decode'
+} from "recharts";
+import type { ModelUsage } from "@/types/claude";
+import { formatTokens } from "@/lib/decode";
 
 interface Props {
-  modelUsage: Record<string, ModelUsage>
+  modelUsage: Record<string, ModelUsage>;
 }
 
 const MODEL_COLORS = [
-  '#d97706', // orange
-  '#34d399', // green
-  '#60a5fa', // blue
-  '#a78bfa', // purple
-  '#fbbf24', // amber
-]
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
 
 function shortModelName(model: string): string {
-  if (model.includes('opus-4-6'))      return 'Opus 4.6'
-  if (model.includes('opus-4-5'))      return 'Opus 4.5'
-  if (model.includes('sonnet-4-6'))    return 'Sonnet 4.6'
-  if (model.includes('sonnet-4-5'))    return 'Sonnet 4.5'
-  if (model.includes('haiku-4-5'))     return 'Haiku 4.5'
+  if (model.includes("opus-4-6")) return "Opus 4.6";
+  if (model.includes("opus-4-5")) return "Opus 4.5";
+  if (model.includes("sonnet-4-6")) return "Sonnet 4.6";
+  if (model.includes("sonnet-4-5")) return "Sonnet 4.5";
+  if (model.includes("haiku-4-5")) return "Haiku 4.5";
   // Generic fallback
-  const parts = model.split('-')
-  return parts.slice(0, 3).join('-')
+  const parts = model.split("-");
+  return parts.slice(0, 3).join("-");
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function CustomTooltip({ active, payload }: any) {
-  if (!active || !payload?.length) return null
-  const { name, value } = payload[0]
+  if (!active || !payload?.length) return null;
+  const { name, value } = payload[0];
   return (
     <div className="bg-card border border-border rounded px-3 py-2 text-[13px]">
       <p className="text-muted-foreground">{name}</p>
       <p className="text-foreground font-bold">{formatTokens(value)} tokens</p>
     </div>
-  )
+  );
 }
 
 export function ModelBreakdownDonut({ modelUsage }: Props) {
   const data = Object.entries(modelUsage)
     .map(([model, usage]) => ({
       name: shortModelName(model),
-      value: (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0) + (usage.cacheCreationInputTokens ?? 0),
+      value:
+        (usage.inputTokens ?? 0) +
+        (usage.outputTokens ?? 0) +
+        (usage.cacheReadInputTokens ?? 0) +
+        (usage.cacheCreationInputTokens ?? 0),
     }))
-    .filter(d => d.value > 0)
-    .sort((a, b) => b.value - a.value)
+    .filter((d) => d.value > 0)
+    .sort((a, b) => b.value - a.value);
 
   if (data.length === 0) {
     return (
       <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
         no model data
       </div>
-    )
+    );
   }
 
   return (
-    <div role="img" aria-label="Model distribution chart"><ResponsiveContainer width="100%" height={220}>
-      <PieChart>
-        <Pie
-          data={data}
-          cx="50%"
-          cy="45%"
-          innerRadius={55}
-          outerRadius={85}
-          paddingAngle={2}
-          dataKey="value"
-          strokeWidth={0}
-        >
-          {data.map((_, i) => (
-            <Cell key={i} fill={MODEL_COLORS[i % MODEL_COLORS.length]} />
-          ))}
-        </Pie>
-        <Tooltip content={<CustomTooltip />} />
-        <Legend
-          iconType="circle"
-          iconSize={8}
-          wrapperStyle={{ fontSize: 12 }}
-          formatter={(value) => (
-            <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>{value}</span>
-          )}
-        />
-      </PieChart>
-    </ResponsiveContainer></div>
-  )
+    <div role="img" aria-label="Model distribution chart">
+      <ResponsiveContainer width="100%" height={220}>
+        <PieChart>
+          <Pie
+            data={data}
+            cx="50%"
+            cy="45%"
+            innerRadius={55}
+            outerRadius={85}
+            paddingAngle={2}
+            dataKey="value"
+            strokeWidth={0}
+          >
+            {data.map((_, i) => (
+              <Cell key={i} fill={MODEL_COLORS[i % MODEL_COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip content={<CustomTooltip />} />
+          <Legend
+            iconType="circle"
+            iconSize={8}
+            wrapperStyle={{ fontSize: 12 }}
+            formatter={(value) => (
+              <span style={{ color: "var(--muted-foreground)", fontSize: 12 }}>
+                {value}
+              </span>
+            )}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
 }

--- a/components/overview/peak-hours-chart.tsx
+++ b/components/overview/peak-hours-chart.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 
 import {
   BarChart,
@@ -9,79 +9,98 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
-} from 'recharts'
-import { useTheme } from '@/components/theme-provider'
+} from "recharts";
+import { useTheme } from "@/components/theme-provider";
 
 interface Props {
-  hourCounts: Record<string, number>
+  hourCounts: Record<string, number>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function CustomTooltip({ active, payload, label }: any) {
-  if (!active || !payload?.length) return null
-  const hour = parseInt(label)
-  const period = hour < 12 ? 'AM' : 'PM'
-  const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour
+  if (!active || !payload?.length) return null;
+  const hour = parseInt(label);
+  const period = hour < 12 ? "AM" : "PM";
+  const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
   return (
     <div className="bg-card border border-border rounded-lg px-3 py-2 text-[13px]">
-      <p className="text-muted-foreground">{h12}:00 {period}</p>
+      <p className="text-muted-foreground">
+        {h12}:00 {period}
+      </p>
       <p className="text-primary font-bold">{payload[0].value} sessions</p>
     </div>
-  )
+  );
 }
 
 export function PeakHoursChart({ hourCounts }: Props) {
-  const { theme } = useTheme()
-  const isDark = theme === 'dark'
+  const { theme } = useTheme();
+  const isDark = theme === "dark";
 
   const data = Array.from({ length: 24 }, (_, i) => ({
     hour: String(i),
     count: hourCounts[String(i)] ?? 0,
-  }))
+  }));
 
-  const sorted = [...data].sort((a, b) => b.count - a.count)
-  const top3Hours = new Set(sorted.slice(0, 3).map(d => d.hour))
+  const sorted = [...data].sort((a, b) => b.count - a.count);
+  const top3Hours = new Set(sorted.slice(0, 3).map((d) => d.hour));
 
   // Light mode: bright amber for top, soft amber for rest
   // Dark mode: keep the original darker tones
-  const topFill    = isDark ? '#d97706' : '#f59e0b'
-  const normalFill = isDark ? '#78350f' : '#fde68a'
-  const strokeColor = isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.4)'
+  const topFill = isDark ? "var(--chart-1)" : "var(--chart-5)";
+  const normalFill = isDark ? "#78350f" : "#fde68a"; // subtle fill — not a data color
+  const strokeColor = isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.4)";
 
   return (
     <div>
-      <div role="img" aria-label="Peak hours activity chart"><ResponsiveContainer width="100%" height={160}>
-        <BarChart data={data} margin={{ top: 4, right: 4, left: -16, bottom: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
-          <XAxis
-            dataKey="hour"
-            tick={{ fontSize: 11, fill: 'var(--muted-foreground)' }}
-            tickLine={false}
-            axisLine={false}
-            tickFormatter={v => {
-              const h = parseInt(v)
-              if (h === 0) return '12a'
-              if (h === 12) return '12p'
-              if (h < 12) return `${h}a`
-              return `${h - 12}p`
-            }}
-          />
-          <YAxis hide />
-          <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(180,83,9,0.08)' }} />
-          <Bar dataKey="count" radius={[2, 2, 0, 0]} maxBarSize={14}
-               stroke={strokeColor} strokeWidth={0.75}>
-            {data.map(d => (
-              <Cell
-                key={d.hour}
-                fill={top3Hours.has(d.hour) ? topFill : normalFill}
-              />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer></div>
+      <div role="img" aria-label="Peak hours activity chart">
+        <ResponsiveContainer width="100%" height={160}>
+          <BarChart
+            data={data}
+            margin={{ top: 4, right: 4, left: -16, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="var(--border)"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="hour"
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(v) => {
+                const h = parseInt(v);
+                if (h === 0) return "12a";
+                if (h === 12) return "12p";
+                if (h < 12) return `${h}a`;
+                return `${h - 12}p`;
+              }}
+            />
+            <YAxis hide />
+            <Tooltip
+              content={<CustomTooltip />}
+              cursor={{ fill: "rgba(180,83,9,0.08)" }}
+            />
+            <Bar
+              dataKey="count"
+              radius={[2, 2, 0, 0]}
+              maxBarSize={14}
+              stroke={strokeColor}
+              strokeWidth={0.75}
+            >
+              {data.map((d) => (
+                <Cell
+                  key={d.hour}
+                  fill={top3Hours.has(d.hour) ? topFill : normalFill}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
       <p className="text-[11px] font-mono text-muted-foreground/60 mt-1">
         top 3 peak hours highlighted
       </p>
     </div>
-  )
+  );
 }

--- a/components/overview/project-activity-donut.tsx
+++ b/components/overview/project-activity-donut.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 
 import {
   PieChart,
@@ -7,40 +7,40 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
-} from 'recharts'
-import type { ProjectSummary } from '@/types/claude'
-import { formatTokens } from '@/lib/decode'
+} from "recharts";
+import type { ProjectSummary } from "@/types/claude";
+import { formatTokens } from "@/lib/decode";
 
 interface Props {
-  projects: ProjectSummary[]
+  projects: ProjectSummary[];
 }
 
 const PROJECT_COLORS = [
-  '#d97706', // reddish-orange (primary)
-  '#166534', // dark green
-  '#0ea5e9', // light blue
-  '#d97706', // orange
-  '#34d399', // light green
-  '#5a6474', // grey (others)
-]
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--muted-foreground)",
+];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function CustomTooltip({ active, payload }: any) {
-  if (!active || !payload?.length) return null
-  const { name, value } = payload[0]
+  if (!active || !payload?.length) return null;
+  const { name, value } = payload[0];
   return (
     <div className="bg-card border border-border rounded px-3 py-2 text-[13px]">
       <p className="text-muted-foreground">{name}</p>
       <p className="text-foreground font-bold">{formatTokens(value)} tokens</p>
     </div>
-  )
+  );
 }
 
 export function ProjectActivityDonut({ projects }: Props) {
   const totalTokens = projects.reduce(
     (s, p) => s + (p.input_tokens ?? 0) + (p.output_tokens ?? 0),
-    0
-  )
+    0,
+  );
 
   const data = projects
     .slice(0, 5)
@@ -48,11 +48,11 @@ export function ProjectActivityDonut({ projects }: Props) {
       name: p.display_name,
       value: (p.input_tokens ?? 0) + (p.output_tokens ?? 0),
     }))
-    .filter((d) => d.value > 0)
+    .filter((d) => d.value > 0);
 
-  const othersTokens = totalTokens - data.reduce((s, d) => s + d.value, 0)
+  const othersTokens = totalTokens - data.reduce((s, d) => s + d.value, 0);
   if (othersTokens > 0) {
-    data.push({ name: 'others', value: othersTokens })
+    data.push({ name: "others", value: othersTokens });
   }
 
   if (data.length === 0) {
@@ -60,36 +60,40 @@ export function ProjectActivityDonut({ projects }: Props) {
       <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
         no project data
       </div>
-    )
+    );
   }
 
   return (
-    <div role="img" aria-label="Project activity chart"><ResponsiveContainer width="100%" height={220}>
-      <PieChart margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
-        <Pie
-          data={data}
-          cx="50%"
-          cy="50%"
-          innerRadius={50}
-          outerRadius={80}
-          paddingAngle={2}
-          dataKey="value"
-          strokeWidth={0}
-        >
-          {data.map((_, i) => (
-            <Cell key={i} fill={PROJECT_COLORS[i % PROJECT_COLORS.length]} />
-          ))}
-        </Pie>
-        <Tooltip content={<CustomTooltip />} />
-        <Legend
-          iconType="circle"
-          iconSize={8}
-          wrapperStyle={{ fontSize: 12 }}
-          formatter={(value) => (
-            <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>{value}</span>
-          )}
-        />
-      </PieChart>
-    </ResponsiveContainer></div>
-  )
+    <div role="img" aria-label="Project activity chart">
+      <ResponsiveContainer width="100%" height={220}>
+        <PieChart margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+          <Pie
+            data={data}
+            cx="50%"
+            cy="50%"
+            innerRadius={50}
+            outerRadius={80}
+            paddingAngle={2}
+            dataKey="value"
+            strokeWidth={0}
+          >
+            {data.map((_, i) => (
+              <Cell key={i} fill={PROJECT_COLORS[i % PROJECT_COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip content={<CustomTooltip />} />
+          <Legend
+            iconType="circle"
+            iconSize={8}
+            wrapperStyle={{ fontSize: 12 }}
+            formatter={(value) => (
+              <span style={{ color: "var(--muted-foreground)", fontSize: 12 }}>
+                {value}
+              </span>
+            )}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
 }

--- a/components/overview/usage-over-time-chart.tsx
+++ b/components/overview/usage-over-time-chart.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 
 import {
   AreaChart,
@@ -9,158 +9,183 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
-} from 'recharts'
-import type { DailyActivity } from '@/types/claude'
-import { format, parseISO, subDays } from 'date-fns'
+} from "recharts";
+import type { DailyActivity } from "@/types/claude";
+import { format, parseISO, subDays } from "date-fns";
 
 interface Props {
-  data: DailyActivity[]
-  days?: number
-  dateFrom?: string
-  dateTo?: string
+  data: DailyActivity[];
+  days?: number;
+  dateFrom?: string;
+  dateTo?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function CustomTooltip({ active, payload, label }: any) {
-  if (!active || !payload?.length) return null
+  if (!active || !payload?.length) return null;
   return (
     <div className="bg-card border border-border rounded-lg px-3 py-2 text-[13px]">
       <p className="text-muted-foreground mb-1">{label}</p>
       {payload.map((p: { name: string; value: number; color: string }) => (
         <p key={p.name} style={{ color: p.color }}>
-          {p.name}: <span className="font-bold">{p.value.toLocaleString()}</span>
+          {p.name}:{" "}
+          <span className="font-bold">{p.value.toLocaleString()}</span>
         </p>
       ))}
     </div>
-  )
+  );
 }
 
 function toIsoDate(val: string): string | null {
-  const m = val.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})$/)
+  const m = val.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})$/);
   if (m) {
-    const [, month, day, year] = m
-    return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
+    const [, month, day, year] = m;
+    return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
   }
-  const iso = val.match(/^(\d{4})-(\d{2})-(\d{2})/)
-  return iso ? val.slice(0, 10) : null
+  const iso = val.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  return iso ? val.slice(0, 10) : null;
 }
 
 function parseDateInput(val: string): Date | null {
-  const parsed = new Date(val)
-  return isNaN(parsed.getTime()) ? null : parsed
+  const parsed = new Date(val);
+  return isNaN(parsed.getTime()) ? null : parsed;
 }
 
-export function UsageOverTimeChart({ data, days = 90, dateFrom, dateTo }: Props) {
-  let filtered: { date: string; messages: number; sessions: number }[]
+export function UsageOverTimeChart({
+  data,
+  days = 90,
+  dateFrom,
+  dateTo,
+}: Props) {
+  let filtered: { date: string; messages: number; sessions: number }[];
 
   if (dateFrom && dateTo) {
-    const fromStr = toIsoDate(dateFrom.trim())
-    const toStr = toIsoDate(dateTo.trim())
+    const fromStr = toIsoDate(dateFrom.trim());
+    const toStr = toIsoDate(dateTo.trim());
     if (fromStr && toStr && fromStr <= toStr) {
       filtered = data
         .filter((d) => {
           const dataDate = /^\d{4}-\d{2}-\d{2}/.test(d.date)
             ? d.date.slice(0, 10)
-            : toIsoDate(d.date)
-          if (!dataDate) return false
-          return dataDate >= fromStr && dataDate <= toStr
+            : toIsoDate(d.date);
+          if (!dataDate) return false;
+          return dataDate >= fromStr && dataDate <= toStr;
         })
         .map((d) => ({
           date: (() => {
             try {
-              const parsed = d.date.includes('-') ? parseISO(d.date) : new Date(d.date)
-              return isNaN(parsed.getTime()) ? d.date : format(parsed, 'MMM d')
+              const parsed = d.date.includes("-")
+                ? parseISO(d.date)
+                : new Date(d.date);
+              return isNaN(parsed.getTime()) ? d.date : format(parsed, "MMM d");
             } catch {
-              return d.date
+              return d.date;
             }
           })(),
           messages: d.messageCount,
           sessions: d.sessionCount,
-        }))
+        }));
     } else {
-      filtered = []
+      filtered = [];
     }
   } else {
-    const cutoff = subDays(new Date(), days)
+    const cutoff = subDays(new Date(), days);
     filtered = data
       .filter((d) => parseISO(d.date) >= cutoff)
       .map((d) => ({
-        date: format(parseISO(d.date), 'MMM d'),
+        date: format(parseISO(d.date), "MMM d"),
         messages: d.messageCount,
         sessions: d.sessionCount,
-      }))
+      }));
   }
 
   if (filtered.length === 0) {
-    const from = dateFrom && dateTo ? parseDateInput(dateFrom) : null
-    const to = dateFrom && dateTo ? parseDateInput(dateTo) : null
-    const isFuture = from && to && from > new Date()
+    const from = dateFrom && dateTo ? parseDateInput(dateFrom) : null;
+    const to = dateFrom && dateTo ? parseDateInput(dateTo) : null;
+    const isFuture = from && to && from > new Date();
     return (
       <div className="flex flex-col items-center justify-center h-48 text-muted-foreground text-sm gap-1">
         <span>no data</span>
         {isFuture && (
-          <span className="text-[12px] text-muted-foreground/60">(selected range is in the future)</span>
+          <span className="text-[12px] text-muted-foreground/60">
+            (selected range is in the future)
+          </span>
         )}
         {dateFrom && dateTo && !isFuture && (
-          <span className="text-[12px] text-muted-foreground/60">(no activity in this date range)</span>
+          <span className="text-[12px] text-muted-foreground/60">
+            (no activity in this date range)
+          </span>
         )}
       </div>
-    )
+    );
   }
 
   return (
-    <div role="img" aria-label="Token usage over time chart"><ResponsiveContainer width="100%" height={220}>
-      <AreaChart data={filtered} margin={{ top: 8, right: 8, left: -10, bottom: 0 }}>
-        <defs>
-          <linearGradient id="gradMessages" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%"  stopColor="#d97706" stopOpacity={0.3} />
-            <stop offset="95%" stopColor="#d97706" stopOpacity={0} />
-          </linearGradient>
-          <linearGradient id="gradSessions" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%"  stopColor="#34d399" stopOpacity={0.2} />
-            <stop offset="95%" stopColor="#34d399" stopOpacity={0} />
-          </linearGradient>
-        </defs>
-        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
-        <XAxis
-          dataKey="date"
-          tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
-          tickLine={false}
-          axisLine={false}
-          interval="preserveStartEnd"
-        />
-        <YAxis
-          tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
-          tickLine={false}
-          axisLine={false}
-          tickFormatter={v => v >= 1000 ? `${(v/1000).toFixed(0)}k` : String(v)}
-        />
-        <Tooltip content={<CustomTooltip />} />
-        <Legend
-          wrapperStyle={{ fontSize: 12, paddingTop: 8 }}
-          formatter={(value) => (
-            <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>{value}</span>
-          )}
-        />
-        <Area
-          type="monotone"
-          dataKey="messages"
-          stroke="#d97706"
-          strokeWidth={2}
-          fill="url(#gradMessages)"
-          dot={false}
-          activeDot={{ r: 3, fill: '#fbbf24' }}
-        />
-        <Area
-          type="monotone"
-          dataKey="sessions"
-          stroke="#34d399"
-          strokeWidth={1.5}
-          fill="url(#gradSessions)"
-          dot={false}
-          activeDot={{ r: 3, fill: '#6ee7b7' }}
-        />
-      </AreaChart>
-    </ResponsiveContainer></div>
-  )
+    <div role="img" aria-label="Token usage over time chart">
+      <ResponsiveContainer width="100%" height={220}>
+        <AreaChart
+          data={filtered}
+          margin={{ top: 8, right: 8, left: -10, bottom: 0 }}
+        >
+          <defs>
+            <linearGradient id="gradMessages" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.4} />
+              <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="gradSessions" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="var(--border)"
+            vertical={false}
+          />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+            tickLine={false}
+            axisLine={false}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v) =>
+              v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v)
+            }
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend
+            wrapperStyle={{ fontSize: 12, paddingTop: 8 }}
+            formatter={(value) => (
+              <span style={{ color: "var(--muted-foreground)", fontSize: 12 }}>
+                {value}
+              </span>
+            )}
+          />
+          <Area
+            type="monotone"
+            dataKey="messages"
+            stroke="var(--chart-1)"
+            strokeWidth={2}
+            fill="url(#gradMessages)"
+            dot={false}
+            activeDot={{ r: 3, fill: "var(--chart-5)" }}
+          />
+          <Area
+            type="monotone"
+            dataKey="sessions"
+            stroke="var(--chart-2)"
+            strokeWidth={1.5}
+            fill="url(#gradSessions)"
+            dot={false}
+            activeDot={{ r: 3, fill: "var(--chart-2)" }}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- 7 chart components: hardcoded hex → `var(--chart-N)` CSS variables
- Dark mode `--chart-1` boosted: `#d97706` → `#f59e0b` (better contrast)
- Area fill opacity increased for dark mode visibility
- Theme switch now auto-updates chart colors

Closes #114, Closes #117 | Milestone: M8

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 119/119 pass
- [ ] CI passes
- [ ] Visual: dark mode charts readable, light mode unchanged