### PR TITLE
fix: overview From date uses earliest dailyActivity

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -73,7 +73,12 @@ export async function GET() {
       ...periods,
       storageBytes,
       sessionCount: sessions.length,
-      firstSessionDate: sessions[sessions.length - 1]?.start_time ?? "",
+      // Use dailyActivity (merged stats-cache + JSONL) for earliest date —
+      // stats-cache may have older data than JSONL sessions alone
+      firstSessionDate:
+        dailyActivity.length > 0
+          ? dailyActivity[0].date
+          : (sessions[sessions.length - 1]?.start_time ?? ""),
     },
   });
 }


### PR DESCRIPTION
## Summary
`firstSessionDate` used JSONL session oldest (2026-03-06) but dailyActivity has data since 2025-12-29. Now uses `dailyActivity[0].date` — the true earliest date from merged stats-cache + JSONL.

## Root Cause
Dual cost source issue (ADR-002): stats-cache covers wider date range than JSONL sessions.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 119/119 pass
- [ ] CI passes
- [ ] `curl /api/stats` returns `firstSessionDate: "2025-12-29"`