### PR TITLE
fix: restore conversations table + View all sessions link

### DIFF
--- a/app/overview-client.tsx
+++ b/app/overview-client.tsx
@@ -8,6 +8,7 @@ import { UsageOverTimeChart } from "@/components/overview/usage-over-time-chart"
 import { ModelBreakdownDonut } from "@/components/overview/model-breakdown-donut";
 import { ProjectActivityDonut } from "@/components/overview/project-activity-donut";
 import { PeakHoursChart } from "@/components/overview/peak-hours-chart";
+import { OverviewConversationTable } from "@/components/overview/conversation-table";
 import { formatTokens, formatBytes } from "@/lib/decode";
 import type { StatsCache } from "@/types/claude";
 import type { SessionWithFacet } from "@/types/claude";
@@ -345,18 +346,18 @@ export function OverviewClient() {
         </div>
       </div>
 
-      {/* ── Sessions link (table moved to /sessions to reduce cognitive load) ── */}
-      <div className="flex items-center justify-between border border-border rounded-lg bg-card px-5 py-3">
-        <span className="text-[13px] text-muted-foreground font-mono">
-          {sessions.length} recent conversations
-        </span>
-        <Link
-          href="/sessions"
-          className="text-[13px] font-mono text-primary hover:text-primary/80 transition-colors"
-        >
-          View all sessions &rarr;
-        </Link>
-      </div>
+      {/* ── Recent conversations ── */}
+      <ChartCard title="Recent conversations">
+        <OverviewConversationTable sessions={sessions} />
+        <div className="mt-3 text-right">
+          <Link
+            href="/sessions"
+            className="text-[12px] font-mono text-primary hover:text-primary/80 transition-colors"
+          >
+            View all {sessions.length} sessions &rarr;
+          </Link>
+        </div>
+      </ChartCard>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Restore OverviewConversationTable on overview page (was removed in #121). Add "View all N sessions →" link below the table for navigation to /sessions.

User feedback: table provides valuable at-a-glance context that the link alone didn't.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 119/119 pass
- [ ] CI passes