### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to cc-lens are documented here. This project follows [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.6.1] — 2026-04-06
+
+### Changed
+
+- **Cache immutable patterns** — `setCachedEntry`, `pruneCache`, `setCachedProjectPath` return new objects (#108)
+- **CSP: removed `unsafe-eval`** — standalone production build doesn't need it (#109)
+
+### Added
+
+- **`--no-browser` CLI flag** — skip browser open for headless/daemon use (#126)
+- **systemd service guide** — `docs/systemd.md` + `cc-lens.service.example` for running as daemon (#126)
+
+### Fixed
+
+- **Overview "From" date** — uses earliest dailyActivity date instead of JSONL session (was missing 2+ months) (#124)
+- **Conversations table restored** on overview + "View all sessions" link (#125)
+
 ## [0.6.0] — 2026-04-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Visualize your token usage, costs, sessions, and projects — all from `~/.claude/`.\
 Zero cloud. Zero telemetry. Your data never leaves your machine.
 
-[![Version](https://img.shields.io/badge/version-0.6.0-orange)](https://github.com/pitimon/cc-lens/releases/tag/v0.6.0)
+[![Version](https://img.shields.io/badge/version-0.6.1-orange)](https://github.com/pitimon/cc-lens/releases/tag/v0.6.1)
 [![CI](https://github.com/pitimon/cc-lens/actions/workflows/ci.yml/badge.svg)](https://github.com/pitimon/cc-lens/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-lens",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-lens",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-lens",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Claude Code Lens — visualize your usage, costs, and sessions from ~/.claude/",
   "author": "pitimon (https://github.com/pitimon)",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Version bump to 0.6.1 + CHANGELOG + README badge.

- Cache immutable patterns (#108)
- CSP unsafe-eval removed (#109)
- --no-browser flag + systemd guide (#126)
- Overview From date fix (#124) + conversations table restored (#125)

## Test plan
- [x] 119/119 tests pass
- [ ] CI passes → merge → tag → release