### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to cc-lens are documented here. This project follows [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.7.1] — 2026-04-06
+
+### Changed
+
+- **Worktree grouping at API level** — projects with same display_name merged, all metrics aggregated (#135)
+- **Chart layout swapped** — project bar chart gets wide column, model donut fits narrow (#137)
+
 ## [0.7.0] — 2026-04-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Visualize your token usage, costs, sessions, and projects — all from `~/.claude/`.\
 Zero cloud. Zero telemetry. Your data never leaves your machine.
 
-[![Version](https://img.shields.io/badge/version-0.7.0-orange)](https://github.com/pitimon/cc-lens/releases/tag/v0.7.0)
+[![Version](https://img.shields.io/badge/version-0.7.1-orange)](https://github.com/pitimon/cc-lens/releases/tag/v0.7.1)
 [![CI](https://github.com/pitimon/cc-lens/actions/workflows/ci.yml/badge.svg)](https://github.com/pitimon/cc-lens/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-lens",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-lens",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-lens",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Claude Code Lens — visualize your usage, costs, and sessions from ~/.claude/",
   "author": "pitimon (https://github.com/pitimon)",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Worktree grouping at API level (#135)
- Chart layout swapped — bar wide, donut narrow (#137)

## Test plan
- [x] 121/121 tests pass
- [ ] CI → merge → tag → release