### PR TITLE
fix: model donut uses session tokens — excludes retired models

### DIFF
--- a/app/overview-client.tsx
+++ b/app/overview-client.tsx
@@ -138,6 +138,21 @@ export function OverviewClient() {
   const projects = projectsData?.projects ?? [];
   const projectCount = projects.length;
 
+  // Compute model usage from JSONL sessions (not stats-cache) to exclude retired models
+  const sessionModelUsage = useMemo(() => {
+    const usage: Record<string, { inputTokens: number; outputTokens: number }> =
+      {};
+    for (const s of sessions) {
+      if (!s.model) continue;
+      const existing = usage[s.model] ?? { inputTokens: 0, outputTokens: 0 };
+      usage[s.model] = {
+        inputTokens: existing.inputTokens + (s.input_tokens ?? 0),
+        outputTokens: existing.outputTokens + (s.output_tokens ?? 0),
+      };
+    }
+    return usage;
+  }, [sessions]);
+
   const chartDays = useMemo(() => {
     if (!dateFrom || !dateTo) return 90;
     try {
@@ -283,7 +298,7 @@ export function OverviewClient() {
           icon={<PieChart className="w-4 h-4" />}
           title="Model distribution"
         >
-          <ModelBreakdownDonut modelUsage={stats.modelUsage} />
+          <ModelBreakdownDonut modelUsage={sessionModelUsage} />
         </ChartCard>
       </div>
 

--- a/components/overview/model-breakdown-donut.tsx
+++ b/components/overview/model-breakdown-donut.tsx
@@ -8,11 +8,10 @@ import {
   ResponsiveContainer,
   Legend,
 } from "recharts";
-import type { ModelUsage } from "@/types/claude";
 import { formatTokens } from "@/lib/decode";
 
 interface Props {
-  modelUsage: Record<string, ModelUsage>;
+  modelUsage: Record<string, { inputTokens: number; outputTokens: number }>;
 }
 
 const MODEL_COLORS = [


### PR DESCRIPTION
## Summary
- Compute model I/O tokens from JSONL sessions instead of stats-cache
- Only active models shown (Opus 4.6 + Sonnet 4.6), retired models excluded
- Donut Props simplified to `{ inputTokens, outputTokens }` — no longer needs full ModelUsage

Closes #140

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 121/121 pass
- [ ] CI passes
- [ ] Visual: donut shows only active models