### PR TITLE
fix: filter synthetic from model donut

### DIFF
--- a/app/overview-client.tsx
+++ b/app/overview-client.tsx
@@ -143,7 +143,8 @@ export function OverviewClient() {
     const usage: Record<string, { inputTokens: number; outputTokens: number }> =
       {};
     for (const s of sessions) {
-      if (!s.model) continue;
+      // Skip empty, internal (<synthetic>), and non-claude models
+      if (!s.model || !s.model.startsWith("claude-")) continue;
       const existing = usage[s.model] ?? { inputTokens: 0, outputTokens: 0 };
       usage[s.model] = {
         inputTokens: existing.inputTokens + (s.input_tokens ?? 0),


### PR DESCRIPTION
## Summary
Filter sessionModelUsage to `claude-*` models only. Excludes `<synthetic>` (internal Anthropic model from memory observer, 254 tokens out of 24M).

## Test plan
- [x] 121/121 tests pass
- [ ] CI passes
- [ ] Visual: donut shows only Opus 4.6 + Sonnet 4.6